### PR TITLE
fix: Reject string literals containing null bytes to prevent SQL corruption

### DIFF
--- a/cel2sql.go
+++ b/cel2sql.go
@@ -1008,6 +1008,10 @@ func (con *converter) visitConst(expr *exprpb.Expr) error {
 	case *exprpb.Constant_StringValue:
 		// Use single quotes for PostgreSQL string literals
 		str := c.GetStringValue()
+		// Reject strings containing null bytes
+		if strings.Contains(str, "\x00") {
+			return errors.New("string literals cannot contain null bytes")
+		}
 		// Escape single quotes by doubling them
 		escaped := strings.ReplaceAll(str, "'", "''")
 		con.str.WriteString("'")

--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -501,3 +501,64 @@ func TestConvert(t *testing.T) {
 		})
 	}
 }
+
+// TestNullByteRejection tests that string literals with null bytes are rejected
+func TestNullByteRejection(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Variable("name", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr string
+	}{
+		{
+			name:    "null byte at start",
+			expr:    `name == "\x00test"`,
+			wantErr: "string literals cannot contain null bytes",
+		},
+		{
+			name:    "null byte in middle",
+			expr:    `name == "test\x00value"`,
+			wantErr: "string literals cannot contain null bytes",
+		},
+		{
+			name:    "null byte at end",
+			expr:    `name == "test\x00"`,
+			wantErr: "string literals cannot contain null bytes",
+		},
+		{
+			name:    "only null byte",
+			expr:    `name == "\x00"`,
+			wantErr: "string literals cannot contain null bytes",
+		},
+		{
+			name:    "multiple null bytes",
+			expr:    `name == "\x00\x00\x00"`,
+			wantErr: "string literals cannot contain null bytes",
+		},
+		{
+			name:    "valid string without null byte",
+			expr:    `name == "valid"`,
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			got, err := cel2sql.Convert(ast)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, "name = 'valid'", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #12 - Rejects CEL string literals containing null bytes (`\x00`) with a clear error message to prevent SQL corruption in PostgreSQL queries.

## Problem

Fuzzing (PR #13) discovered that string literals with null bytes generate SQL with unescaped null bytes:

**Input CEL:** `name == "\x00"`  
**Previous output:** `name = '�'` (contains literal null byte)  
**Issue:** Null bytes can terminate strings unexpectedly in C-based PostgreSQL internals, causing query corruption

## Solution

Added null byte detection in `visitConst()` function (cel2sql.go:1012-1014):

```go
// Reject strings containing null bytes
if strings.Contains(str, "\x00") {
    return errors.New("string literals cannot contain null bytes")
}
```

## Changes

### cel2sql.go
- Added null byte check before string escaping in `visitConst()`
- Returns clear error message when null bytes detected
- Placed check before quote escaping for early rejection

### cel2sql_test.go
- Added `TestNullByteRejection` with 6 comprehensive test cases:
  - Null byte at start: `"\x00test"`
  - Null byte in middle: `"test\x00value"`
  - Null byte at end: `"test\x00"`
  - Only null byte: `"\x00"`
  - Multiple null bytes: `"\x00\x00\x00"`
  - Valid string without null byte (regression test)

## Test Results

```bash
$ go test -v -run=TestNullByteRejection
=== RUN   TestNullByteRejection
=== RUN   TestNullByteRejection/null_byte_at_start
=== RUN   TestNullByteRejection/null_byte_in_middle
=== RUN   TestNullByteRejection/null_byte_at_end
=== RUN   TestNullByteRejection/only_null_byte
=== RUN   TestNullByteRejection/multiple_null_bytes
=== RUN   TestNullByteRejection/valid_string_without_null_byte
--- PASS: TestNullByteRejection (0.00s)
PASS
```

All existing tests continue to pass (41.0% coverage maintained).

## Security Impact

- **Prevents SQL corruption:** Null bytes can no longer reach PostgreSQL queries
- **Clear error messaging:** Users receive actionable error instead of silent corruption
- **Data integrity:** String comparisons and operations remain safe
- **Minimal performance impact:** Single `strings.Contains()` check per string literal

## Alternative Approach Considered

We could have escaped null bytes using PostgreSQL's hex encoding (`E'\\x00'`), but rejection is safer because:
1. Null bytes in application strings are almost always unintentional
2. Clear errors help developers catch bugs early
3. PostgreSQL handles null bytes inconsistently in different contexts
4. Rejection aligns with principle of least surprise

## Breaking Change?

**No** - This is not a breaking change because:
- CEL expressions with null bytes were already producing corrupted SQL
- The fuzzer found this as a crash case (it didn't work correctly before)
- Users experiencing this issue would want it to fail explicitly rather than silently

## Related

- Discovered by: PR #13 (fuzzing infrastructure)
- Fixes: #12 (null byte handling bug)
- Crash input preserved: `testdata/fuzz/FuzzConvert/299bc76ba66bca6b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>