### PR TITLE
fix: Reject null bytes in LIKE patterns for startsWith/endsWith functions

### DIFF
--- a/cel2sql.go
+++ b/cel2sql.go
@@ -279,6 +279,10 @@ func (con *converter) callStartsWith(target *exprpb.Expr, args []*exprpb.Expr) e
 	// If it's a constant string, we can append % directly
 	if constExpr := args[0].GetConstExpr(); constExpr != nil && constExpr.GetStringValue() != "" {
 		prefix := constExpr.GetStringValue()
+		// Reject patterns containing null bytes
+		if strings.Contains(prefix, "\x00") {
+			return errors.New("LIKE patterns cannot contain null bytes")
+		}
 		// Escape special LIKE characters: %, _, \
 		escaped := escapeLikePattern(prefix)
 		con.str.WriteString("'")
@@ -316,6 +320,10 @@ func (con *converter) callEndsWith(target *exprpb.Expr, args []*exprpb.Expr) err
 	// If it's a constant string, we can prepend % directly
 	if constExpr := args[0].GetConstExpr(); constExpr != nil && constExpr.GetStringValue() != "" {
 		suffix := constExpr.GetStringValue()
+		// Reject patterns containing null bytes
+		if strings.Contains(suffix, "\x00") {
+			return errors.New("LIKE patterns cannot contain null bytes")
+		}
 		// Escape special LIKE characters: %, _, \
 		escaped := escapeLikePattern(suffix)
 		con.str.WriteString("'%")

--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -562,3 +562,75 @@ func TestNullByteRejection(t *testing.T) {
 		})
 	}
 }
+
+// TestNullByteInLikePatterns tests that LIKE patterns with null bytes are rejected
+func TestNullByteInLikePatterns(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Variable("name", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr string
+	}{
+		{
+			name:    "startsWith with null byte at start",
+			expr:    `name.startsWith("\x00test")`,
+			wantErr: "LIKE patterns cannot contain null bytes",
+		},
+		{
+			name:    "startsWith with null byte in middle",
+			expr:    `name.startsWith("test\x00value")`,
+			wantErr: "LIKE patterns cannot contain null bytes",
+		},
+		{
+			name:    "startsWith with only null byte",
+			expr:    `name.startsWith("\x00")`,
+			wantErr: "LIKE patterns cannot contain null bytes",
+		},
+		{
+			name:    "endsWith with null byte at end",
+			expr:    `name.endsWith("test\x00")`,
+			wantErr: "LIKE patterns cannot contain null bytes",
+		},
+		{
+			name:    "endsWith with null byte in middle",
+			expr:    `name.endsWith("\x00value")`,
+			wantErr: "LIKE patterns cannot contain null bytes",
+		},
+		{
+			name:    "endsWith with only null byte",
+			expr:    `name.endsWith("\x00")`,
+			wantErr: "LIKE patterns cannot contain null bytes",
+		},
+		{
+			name:    "startsWith valid pattern",
+			expr:    `name.startsWith("valid")`,
+			wantErr: "",
+		},
+		{
+			name:    "endsWith valid pattern",
+			expr:    `name.endsWith("valid")`,
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			got, err := cel2sql.Convert(ast)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				// Just verify it doesn't error - actual SQL format tested elsewhere
+				assert.NotEmpty(t, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #15 - Rejects null bytes (`\x00`) in LIKE patterns generated by `startsWith()` and `endsWith()` functions to prevent SQL corruption.

## Problem

Issue #15 was discovered by the fuzzer in PR #13. While PR #14 fixed null bytes in string literals, it missed LIKE patterns generated by string functions:

**Input CEL:** `name.startsWith("\x00")`  
**Previous output:** `name LIKE '\x00%'` (contains literal null byte)  
**Issue:** Null bytes can corrupt PostgreSQL LIKE pattern matching

## Root Cause

PR #14 added null byte checking in `visitConst()` which handles string literals like:
```cel
name == "\x00"  // ✓ Fixed in #14
```

But it didn't cover pattern arguments in string functions:
```cel
name.startsWith("\x00")  // ✗ Not covered by #14
name.endsWith("\x00")    // ✗ Not covered by #14
```

The `callStartsWith()` and `callEndsWith()` functions extract the pattern value directly and generate LIKE clauses without null byte validation.

## Solution

Added null byte detection in both functions before LIKE pattern generation:

### cel2sql.go:282-285 (callStartsWith)
```go
prefix := constExpr.GetStringValue()
// Reject patterns containing null bytes
if strings.Contains(prefix, "\x00") {
    return errors.New("LIKE patterns cannot contain null bytes")
}
```

### cel2sql.go:323-326 (callEndsWith)
```go
suffix := constExpr.GetStringValue()
// Reject patterns containing null bytes
if strings.Contains(suffix, "\x00") {
    return errors.New("LIKE patterns cannot contain null bytes")
}
```

## Changes

### cel2sql.go
- Added null byte check in `callStartsWith()` (lines 282-285)
- Added null byte check in `callEndsWith()` (lines 323-326)
- Both return clear error message when null bytes detected

### cel2sql_test.go
- Added `TestNullByteInLikePatterns` with 8 comprehensive test cases:
  - `startsWith` with null byte at start, middle, only
  - `endsWith` with null byte at end, middle, only
  - Valid patterns for both functions (regression tests)

## Test Results

```bash
$ go test -v -run=TestNullByteInLikePatterns
=== RUN   TestNullByteInLikePatterns
=== RUN   TestNullByteInLikePatterns/startsWith_with_null_byte_at_start
=== RUN   TestNullByteInLikePatterns/startsWith_with_null_byte_in_middle
=== RUN   TestNullByteInLikePatterns/startsWith_with_only_null_byte
=== RUN   TestNullByteInLikePatterns/endsWith_with_null_byte_at_end
=== RUN   TestNullByteInLikePatterns/endsWith_with_null_byte_in_middle
=== RUN   TestNullByteInLikePatterns/endsWith_with_only_null_byte
=== RUN   TestNullByteInLikePatterns/startsWith_valid_pattern
=== RUN   TestNullByteInLikePatterns/endsWith_valid_pattern
--- PASS: TestNullByteInLikePatterns (0.00s)
PASS
```

All existing tests continue to pass (41.2% coverage maintained).

## What About contains()?

The `callContains()` function uses `POSITION()` instead of `LIKE`:
```sql
POSITION('search' IN field) > 0
```

Since it processes the search string through `visit()` which calls `visitConst()`, null bytes are already caught by the fix in #14. No additional fix needed for `contains()`.

## Security Impact

- **Prevents SQL corruption:** Null bytes can no longer reach LIKE patterns
- **Consistent error handling:** Same error message as string literals (#14)
- **Complete coverage:** Combined with #14, all null byte entry points now protected
- **Minimal performance impact:** Single `strings.Contains()` check per pattern

## Discovered By

- **Fuzzer**: `FuzzEscapeLikePattern` from PR #13
- **CI Run**: https://github.com/SPANDigital/cel2sql/actions/runs/18400783446
- **Job ID**: 52429323134
- **Crash input**: `testdata/fuzz/FuzzEscapeLikePattern/390ca22614d4ce1a`

This demonstrates the value of comprehensive fuzzing - it found this issue within seconds of the first CI run!

## Related

- Discovered by: PR #13 (fuzzing infrastructure)
- Fixes: #15 (null bytes in LIKE patterns)
- Related to: #12, PR #14 (null bytes in string literals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>