### PR TITLE
Fix JSON path operators: Use schema-based detection and correct table.column handling

### DIFF
--- a/cel2sql.go
+++ b/cel2sql.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/overloads"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
+	"github.com/spandigital/cel2sql/v2/pg"
 )
 
 // Implementations based on `google/cel-go`'s unparser
@@ -18,12 +20,19 @@ import (
 
 // Convert converts a CEL AST to a PostgreSQL SQL WHERE clause condition.
 func Convert(ast *cel.Ast) (string, error) {
+	return ConvertWithSchemas(ast, nil)
+}
+
+// ConvertWithSchemas converts a CEL AST to a PostgreSQL SQL WHERE clause condition,
+// using schema information to properly handle JSON/JSONB fields.
+func ConvertWithSchemas(ast *cel.Ast, schemas map[string]pg.Schema) (string, error) {
 	checkedExpr, err := cel.AstToCheckedExpr(ast)
 	if err != nil {
 		return "", err
 	}
 	un := &converter{
 		typeMap: checkedExpr.TypeMap,
+		schemas: schemas,
 	}
 	if err := un.visit(checkedExpr.Expr); err != nil {
 		return "", err
@@ -34,6 +43,7 @@ func Convert(ast *cel.Ast) (string, error) {
 type converter struct {
 	str     strings.Builder
 	typeMap map[int64]*exprpb.Type
+	schemas map[string]pg.Schema
 }
 
 func (con *converter) visit(expr *exprpb.Expr) error {
@@ -55,6 +65,46 @@ func (con *converter) visit(expr *exprpb.Expr) error {
 		return con.visitStruct(expr)
 	}
 	return fmt.Errorf("unsupported expr: %v", expr)
+}
+
+// isFieldJSON checks if a field in a table is a JSON/JSONB type using schema information
+func (con *converter) isFieldJSON(tableName, fieldName string) bool {
+	if con.schemas == nil {
+		return false
+	}
+
+	schema, ok := con.schemas[tableName]
+	if !ok {
+		return false
+	}
+
+	for _, field := range schema {
+		if field.Name == fieldName {
+			return field.IsJSON
+		}
+	}
+
+	return false
+}
+
+// getTableAndFieldFromSelectChain extracts the table name and field name from a select expression chain
+// For obj.metadata, it returns ("obj", "metadata")
+func (con *converter) getTableAndFieldFromSelectChain(expr *exprpb.Expr) (string, string, bool) {
+	selectExpr := expr.GetSelectExpr()
+	if selectExpr == nil {
+		return "", "", false
+	}
+
+	fieldName := selectExpr.GetField()
+	operand := selectExpr.GetOperand()
+
+	// Check if the operand is an identifier (table name)
+	if identExpr := operand.GetIdentExpr(); identExpr != nil {
+		tableName := identExpr.GetName()
+		return tableName, fieldName, true
+	}
+
+	return "", "", false
 }
 
 func (con *converter) visitCall(expr *exprpb.Expr) error {
@@ -377,11 +427,11 @@ func (con *converter) callCasting(function string, _ *exprpb.Expr, args []*exprp
 func (con *converter) callMatches(target *exprpb.Expr, args []*exprpb.Expr) error {
 	// CEL matches function: string.matches(pattern) or matches(string, pattern)
 	// Convert to PostgreSQL: string ~ 'posix_pattern'
-	
+
 	// Get the string to match against
 	var stringExpr *exprpb.Expr
 	var patternExpr *exprpb.Expr
-	
+
 	if target != nil {
 		// Method call: string.matches(pattern)
 		stringExpr = target
@@ -393,18 +443,18 @@ func (con *converter) callMatches(target *exprpb.Expr, args []*exprpb.Expr) erro
 		stringExpr = args[0]
 		patternExpr = args[1]
 	}
-	
+
 	if stringExpr == nil || patternExpr == nil {
 		return errors.New("matches function requires both string and pattern arguments")
 	}
-	
+
 	// Visit the string expression
 	if err := con.visit(stringExpr); err != nil {
 		return err
 	}
-	
+
 	con.str.WriteString(" ~ ")
-	
+
 	// Visit the pattern expression and convert from RE2 to POSIX if it's a string literal
 	if constExpr := patternExpr.GetConstExpr(); constExpr != nil && constExpr.GetStringValue() != "" {
 		// Convert RE2 pattern to POSIX
@@ -427,7 +477,7 @@ func (con *converter) callMatches(target *exprpb.Expr, args []*exprpb.Expr) erro
 			return err
 		}
 	}
-	
+
 	return nil
 }
 
@@ -1442,35 +1492,35 @@ func isBinaryOrTernaryOperator(expr *exprpb.Expr) bool {
 // Note: This is a basic conversion for common patterns. Full RE2 to POSIX conversion is complex.
 func convertRE2ToPOSIX(re2Pattern string) string {
 	posixPattern := re2Pattern
-	
+
 	// Basic conversions for common differences between RE2 and POSIX:
-	
+
 	// 1. Word boundaries: \b -> [[:<:]] and [[:<:]] (PostgreSQL extension)
 	//    Note: PostgreSQL supports \y for word boundaries in some contexts
 	posixPattern = strings.ReplaceAll(posixPattern, `\b`, `\y`)
-	
+
 	// 2. Non-word boundaries: \B -> [^[:alnum:]_] (approximate)
 	//    This is a simplification; exact conversion is complex
 	posixPattern = strings.ReplaceAll(posixPattern, `\B`, `[^[:alnum:]_]`)
-	
+
 	// 3. Digit shortcuts: \d -> [[:digit:]] or [0-9]
 	posixPattern = strings.ReplaceAll(posixPattern, `\d`, `[[:digit:]]`)
-	
+
 	// 4. Non-digit shortcuts: \D -> [^[:digit:]] or [^0-9]
 	posixPattern = strings.ReplaceAll(posixPattern, `\D`, `[^[:digit:]]`)
-	
+
 	// 5. Word character shortcuts: \w -> [[:alnum:]_]
 	posixPattern = strings.ReplaceAll(posixPattern, `\w`, `[[:alnum:]_]`)
-	
+
 	// 6. Non-word character shortcuts: \W -> [^[:alnum:]_]
 	posixPattern = strings.ReplaceAll(posixPattern, `\W`, `[^[:alnum:]_]`)
-	
+
 	// 7. Whitespace shortcuts: \s -> [[:space:]]
 	posixPattern = strings.ReplaceAll(posixPattern, `\s`, `[[:space:]]`)
-	
+
 	// 8. Non-whitespace shortcuts: \S -> [^[:space:]]
 	posixPattern = strings.ReplaceAll(posixPattern, `\S`, `[^[:space:]]`)
-	
+
 	// Note: Many RE2 features are not directly convertible to POSIX ERE:
 	// - Lookahead/lookbehind assertions (?=...), (?!...), (?<=...), (?<!...)
 	// - Non-capturing groups (?:...)
@@ -1478,9 +1528,9 @@ func convertRE2ToPOSIX(re2Pattern string) string {
 	// - Case-insensitive flags (?i)
 	// - Multiline flags (?m)
 	// - Unicode character classes
-	// 
+	//
 	// For these cases, the pattern is returned as-is, which may cause PostgreSQL errors
 	// if the pattern uses unsupported RE2 features.
-	
+
 	return posixPattern
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24
 require (
 	github.com/google/cel-go v0.26.0
 	github.com/jackc/pgx/v5 v5.7.5
+	github.com/lib/pq v1.10.9
 	github.com/spandigital/cel2sql v0.0.0-20250719023919-4359e01a942f
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.38.0

--- a/json.go
+++ b/json.go
@@ -15,27 +15,27 @@ const (
 )
 
 // shouldUseJSONPath determines if we should use JSON path operators for field access
+// This function checks if the operand represents a JSON/JSONB field using schema information
 func (con *converter) shouldUseJSONPath(operand *exprpb.Expr, _ string) bool {
-	// For now, we'll use a simple heuristic: if the operand is a direct field reference
-	// to a field that commonly contains JSON (like 'preferences', 'metadata', 'profile', 'details')
-	// then we use JSON path operators
-	if identExpr := operand.GetIdentExpr(); identExpr != nil {
-		// Direct field access - check if it's a known JSON field
-		return false // We don't have direct JSON field access in our current tests
-	}
-
+	// Check if the operand is a direct table.column access where column is JSON
 	if selectExpr := operand.GetSelectExpr(); selectExpr != nil {
-		// Nested field access - check if the parent field is a JSON field
-		parentField := selectExpr.GetField()
-		jsonFields := []string{"preferences", "metadata", "profile", "details", "settings", "properties", "analytics", 
-		                      "content", "structure", "taxonomy", "classification", "content_structure"}
-		for _, jsonField := range jsonFields {
-			if parentField == jsonField {
+		// For obj.metadata, check if metadata is a JSON column in obj table
+		if tableName, fieldName, ok := con.getTableAndFieldFromSelectChain(operand); ok {
+			// Use schema information to determine if this field is JSON
+			if con.isFieldJSON(tableName, fieldName) {
 				return true
 			}
+			// Fallback to hardcoded list for backward compatibility when schemas not provided
+			jsonFields := []string{"preferences", "metadata", "profile", "details", "settings", "properties", "analytics",
+				"content", "structure", "taxonomy", "classification", "content_structure"}
+			for _, jsonField := range jsonFields {
+				if fieldName == jsonField {
+					return true
+				}
+			}
 		}
-		
-		// Also check if we have deeper nesting where a JSON field appears earlier in the chain
+
+		// Check if there's a JSON field somewhere in the operand chain
 		if con.hasJSONFieldInChain(operand) {
 			return true
 		}
@@ -49,20 +49,20 @@ func (con *converter) hasJSONFieldInChain(expr *exprpb.Expr) bool {
 	if selectExpr := expr.GetSelectExpr(); selectExpr != nil {
 		field := selectExpr.GetField()
 		operand := selectExpr.GetOperand()
-		
+
 		// Check if current field is a JSON field
-		jsonFields := []string{"preferences", "metadata", "profile", "details", "settings", "properties", "analytics", 
-		                      "content", "structure", "taxonomy", "classification", "content_structure"}
+		jsonFields := []string{"preferences", "metadata", "profile", "details", "settings", "properties", "analytics",
+			"content", "structure", "taxonomy", "classification", "content_structure"}
 		for _, jsonField := range jsonFields {
 			if field == jsonField {
 				return true
 			}
 		}
-		
+
 		// Recursively check the operand
 		return con.hasJSONFieldInChain(operand)
 	}
-	
+
 	return false
 }
 
@@ -73,11 +73,11 @@ func (con *converter) isJSONTextExtraction(expr *exprpb.Expr) bool {
 	if selectExpr := expr.GetSelectExpr(); selectExpr != nil {
 		operand := selectExpr.GetOperand()
 		field := selectExpr.GetField()
-		
+
 		// If this would trigger JSON path generation, it's a text extraction
 		return con.shouldUseJSONPath(operand, field)
 	}
-	
+
 	return false
 }
 
@@ -85,26 +85,26 @@ func (con *converter) isJSONTextExtraction(expr *exprpb.Expr) bool {
 func (con *converter) needsNumericCasting(identName string) bool {
 	// Common iteration variable names that come from numeric JSON arrays
 	numericIterationVars := []string{"score", "value", "num", "amount", "count", "level"}
-	
+
 	for _, numericVar := range numericIterationVars {
 		if identName == numericVar {
 			return true
 		}
 	}
-	
+
 	return false
 }
 
 // isNumericJSONField checks if a JSON field name typically contains numeric values
 func (con *converter) isNumericJSONField(fieldName string) bool {
 	numericFields := []string{"level", "score", "value", "count", "amount", "price", "rating", "age", "size", "capacity", "megapixels", "cores", "threads", "ram", "storage", "vram", "weight", "frequency", "helpful"}
-	
+
 	for _, numericField := range numericFields {
 		if fieldName == numericField {
 			return true
 		}
 	}
-	
+
 	return false
 }
 
@@ -178,13 +178,13 @@ func (con *converter) buildJSONPathForArray(expr *exprpb.Expr) error {
 func (con *converter) isJSONObjectFieldAccess(expr *exprpb.Expr) bool {
 	if selectExpr := expr.GetSelectExpr(); selectExpr != nil {
 		operand := selectExpr.GetOperand()
-		
+
 		// Check if the operand is an identifier that could be a comprehension variable
 		if identExpr := operand.GetIdentExpr(); identExpr != nil {
 			// Common comprehension variable names that access JSON objects
 			jsonObjectVars := []string{"attr", "item", "element", "obj", "feature", "review"}
 			identName := identExpr.GetName()
-			
+
 			for _, jsonVar := range jsonObjectVars {
 				if identName == jsonVar {
 					return true
@@ -219,10 +219,10 @@ func (con *converter) isJSONArrayField(expr *exprpb.Expr) bool {
 			jsonArrayFields := map[string][]string{
 				"json_users":         {"tags", "scores", "attributes"},
 				"json_products":      {"features", "reviews", "categories"},
-				"users":              {"preferences", "profile"}, // existing test data
-				"products":           {"metadata", "details"},    // existing test data
+				"users":              {"preferences", "profile"},                                        // existing test data
+				"products":           {"metadata", "details"},                                           // existing test data
 				"information_assets": {"metadata", "properties", "classification", "content_structure"}, // nested path test data
-				"documents":          {"content", "structure", "taxonomy", "analytics"},                  // nested path test data
+				"documents":          {"content", "structure", "taxonomy", "analytics"},                 // nested path test data
 			}
 
 			if fields, exists := jsonArrayFields[tableName]; exists {
@@ -263,7 +263,7 @@ func (con *converter) isJSONBField(expr *exprpb.Expr) bool {
 
 			// Define which fields are JSONB vs JSON in our test schemas
 			jsonbFields := map[string][]string{
-				"json_users":         {"settings", "tags", "scores"},       // JSONB fields
+				"json_users":         {"settings", "tags", "scores"},        // JSONB fields
 				"json_products":      {"features", "reviews", "properties"}, // JSONB fields
 				"information_assets": {"metadata", "classification"},        // JSONB fields
 				"documents":          {"content", "taxonomy"},               // JSONB fields
@@ -296,10 +296,10 @@ func (con *converter) isJSONBField(expr *exprpb.Expr) bool {
 func (con *converter) getJSONArrayFunction(expr *exprpb.Expr) string {
 	// Determine if this is JSON or JSONB based on the field
 	isJSONB := con.isJSONBField(expr)
-	
+
 	if selectExpr := expr.GetSelectExpr(); selectExpr != nil {
 		field := selectExpr.GetField()
-		
+
 		// Fields that contain simple values (strings, numbers)
 		simpleArrayFields := []string{"tags", "scores", "categories"}
 		for _, simpleField := range simpleArrayFields {
@@ -311,7 +311,7 @@ func (con *converter) getJSONArrayFunction(expr *exprpb.Expr) string {
 				return jsonArrayElementsText
 			}
 		}
-		
+
 		// Fields that contain complex objects
 		complexArrayFields := []string{"attributes", "features", "reviews"}
 		for _, complexField := range complexArrayFields {
@@ -322,7 +322,7 @@ func (con *converter) getJSONArrayFunction(expr *exprpb.Expr) string {
 				return jsonArrayElements
 			}
 		}
-		
+
 		// For nested JSON access, use appropriate array elements function
 		if operand := selectExpr.GetOperand(); operand.GetSelectExpr() != nil {
 			if isJSONB {
@@ -331,7 +331,7 @@ func (con *converter) getJSONArrayFunction(expr *exprpb.Expr) string {
 			return jsonArrayElements
 		}
 	}
-	
+
 	// Default based on field type
 	if isJSONB {
 		return jsonbArrayElements
@@ -356,7 +356,26 @@ func (con *converter) buildJSONPathInternal(expr *exprpb.Expr, isFinalField bool
 
 	// Check if the operand is also a select expression (nested access)
 	if operandSelect := operand.GetSelectExpr(); operandSelect != nil {
-		// This is nested access like table.jsonfield.subfield.finalfield
+		// Check if this is a direct table.column access (e.g., obj.metadata)
+		// If so, we should NOT apply JSON operators to this level
+		if tableName, columnName, ok := con.getTableAndFieldFromSelectChain(operand); ok {
+			// This is table.column where column is JSON/JSONB
+			// Render as table.column without JSON operators
+			con.str.WriteString(tableName)
+			con.str.WriteString(".")
+			con.str.WriteString(columnName)
+			// Now add JSON operator for the current field
+			if isFinalField {
+				con.str.WriteString("->>'") // Final field: extract as text
+			} else {
+				con.str.WriteString("->'") // Intermediate field: keep as JSON
+			}
+			con.str.WriteString(escapeJSONFieldName(field))
+			con.str.WriteString("'")
+			return nil
+		}
+
+		// This is deeper nesting like table.jsonfield.subfield.finalfield
 		// We need to determine if the operand is JSON-related
 		if con.shouldUseJSONPath(operandSelect.GetOperand(), operandSelect.GetField()) {
 			// Recursively build the path for the operand (not final since we have more fields)
@@ -365,9 +384,9 @@ func (con *converter) buildJSONPathInternal(expr *exprpb.Expr, isFinalField bool
 			}
 			// Add appropriate JSON path operator based on whether this is the final field
 			if isFinalField {
-				con.str.WriteString("->>'")  // Final field: extract as text
+				con.str.WriteString("->>'") // Final field: extract as text
 			} else {
-				con.str.WriteString("->'")   // Intermediate field: keep as JSON
+				con.str.WriteString("->'") // Intermediate field: keep as JSON
 			}
 			con.str.WriteString(escapeJSONFieldName(field))
 			con.str.WriteString("'")
@@ -382,9 +401,9 @@ func (con *converter) buildJSONPathInternal(expr *exprpb.Expr, isFinalField bool
 
 	// Add the appropriate JSON path operator based on whether this is the final field
 	if isFinalField {
-		con.str.WriteString("->>'")  // Final field: extract as text
+		con.str.WriteString("->>'") // Final field: extract as text
 	} else {
-		con.str.WriteString("->'")   // Intermediate field: keep as JSON
+		con.str.WriteString("->'") // Intermediate field: keep as JSON
 	}
 	con.str.WriteString(escapeJSONFieldName(field))
 	con.str.WriteString("'")

--- a/json_escaping_test.go
+++ b/json_escaping_test.go
@@ -15,7 +15,7 @@ func TestJSONFieldNameEscaping_SingleQuote(t *testing.T) {
 	// Create a schema with a JSON field that might have field names with single quotes
 	testSchema := pg.Schema{
 		{Name: "id", Type: "integer"},
-		{Name: "metadata", Type: "jsonb"},
+		{Name: "metadata", Type: "jsonb", IsJSON: true},
 	}
 
 	provider := pg.NewTypeProvider(map[string]pg.Schema{
@@ -23,21 +23,21 @@ func TestJSONFieldNameEscaping_SingleQuote(t *testing.T) {
 	})
 
 	tests := []struct {
-		name           string
-		celExpr        string
-		expectedSQL    string
-		description    string
+		name        string
+		celExpr     string
+		expectedSQL string
+		description string
 	}{
 		{
 			name:        "JSON field with single quote in name",
 			celExpr:     `obj.metadata.user_name == "test"`,
-			expectedSQL: `obj->>'metadata'->>'user_name' = 'test'`,
+			expectedSQL: `obj.metadata->>'user_name' = 'test'`,
 			description: "Normal field name without quotes",
 		},
 		{
 			name:        "Nested JSON access",
 			celExpr:     `obj.metadata.settings.theme == "dark"`,
-			expectedSQL: `obj->>'metadata'->'settings'->>'theme' = 'dark'`,
+			expectedSQL: `obj.metadata->'settings'->>'theme' = 'dark'`,
 			description: "Nested JSON path",
 		},
 	}
@@ -55,7 +55,10 @@ func TestJSONFieldNameEscaping_SingleQuote(t *testing.T) {
 				t.Fatalf("CEL compilation failed: %v", issues.Err())
 			}
 
-			sqlCondition, err := cel2sql.Convert(ast)
+			schemas := map[string]pg.Schema{
+				"obj": testSchema,
+			}
+			sqlCondition, err := cel2sql.ConvertWithSchemas(ast, schemas)
 			require.NoError(t, err, "Should convert CEL to SQL: %s", tt.description)
 			require.Equal(t, tt.expectedSQL, sqlCondition, "SQL should match expected output")
 		})
@@ -74,7 +77,7 @@ func TestJSONFieldNameEscaping_Documentation(t *testing.T) {
 func TestJSONFieldNameEscaping_HasFunction(t *testing.T) {
 	testSchema := pg.Schema{
 		{Name: "id", Type: "integer"},
-		{Name: "settings", Type: "jsonb"},
+		{Name: "settings", Type: "jsonb", IsJSON: true},
 	}
 
 	provider := pg.NewTypeProvider(map[string]pg.Schema{
@@ -106,7 +109,10 @@ func TestJSONFieldNameEscaping_HasFunction(t *testing.T) {
 				t.Fatalf("CEL compilation failed: %v", issues.Err())
 			}
 
-			sqlCondition, err := cel2sql.Convert(ast)
+			schemas := map[string]pg.Schema{
+				"obj": testSchema,
+			}
+			sqlCondition, err := cel2sql.ConvertWithSchemas(ast, schemas)
 			require.NoError(t, err, "Should convert CEL to SQL: %s", tt.description)
 			require.NotEmpty(t, sqlCondition, "Should generate SQL")
 			t.Logf("Generated SQL: %s", sqlCondition)

--- a/json_integration_validation_test.go
+++ b/json_integration_validation_test.go
@@ -1,0 +1,163 @@
+package cel2sql_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/spandigital/cel2sql/v2"
+	"github.com/spandigital/cel2sql/v2/pg"
+)
+
+// TestGeneratedSQLAgainstPostgreSQL tests if our generated SQL actually works against PostgreSQL
+func TestGeneratedSQLAgainstPostgreSQL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// Start PostgreSQL container
+	req := testcontainers.ContainerRequest{
+		Image:        "postgres:17-alpine",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_PASSWORD": "password",
+			"POSTGRES_DB":       "testdb",
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+	}
+
+	postgresContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+	defer func() {
+		if err := postgresContainer.Terminate(ctx); err != nil {
+			t.Logf("failed to terminate container: %s", err)
+		}
+	}()
+
+	// Get connection string
+	host, err := postgresContainer.Host(ctx)
+	require.NoError(t, err)
+	port, err := postgresContainer.MappedPort(ctx, "5432")
+	require.NoError(t, err)
+
+	connStr := "host=" + host + " port=" + port.Port() + " user=postgres password=password dbname=testdb sslmode=disable"
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Logf("failed to close db: %v", closeErr)
+		}
+	}()
+
+	// Create test table matching our CEL schema
+	_, err = db.Exec(`CREATE TABLE obj (id INT, metadata JSONB)`)
+	require.NoError(t, err)
+
+	// Insert test data
+	_, err = db.Exec(`INSERT INTO obj VALUES (1, '{"user_name": "test", "settings": {"theme": "dark"}}')`)
+	require.NoError(t, err)
+
+	// Set up CEL environment
+	testSchema := pg.Schema{
+		{Name: "id", Type: "integer"},
+		{Name: "metadata", Type: "jsonb", IsJSON: true},
+	}
+
+	provider := pg.NewTypeProvider(map[string]pg.Schema{
+		"TestTable": testSchema,
+	})
+
+	env, err := cel.NewEnv(
+		cel.CustomTypeProvider(provider),
+		cel.Variable("obj", cel.ObjectType("TestTable")),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		celExpr     string
+		shouldWork  bool
+		description string
+	}{
+		{
+			name:        "Simple JSON field access",
+			celExpr:     `obj.metadata.user_name == "test"`,
+			shouldWork:  true,
+			description: "Access nested JSON field",
+		},
+		{
+			name:        "Nested JSON access",
+			celExpr:     `obj.metadata.settings.theme == "dark"`,
+			shouldWork:  true,
+			description: "Access deeply nested JSON field",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Compile CEL expression
+			ast, issues := env.Compile(tt.celExpr)
+			if issues != nil && issues.Err() != nil {
+				t.Fatalf("CEL compilation failed: %v", issues.Err())
+			}
+
+			// Convert to SQL using schema information
+			schemas := map[string]pg.Schema{
+				"obj": testSchema,
+			}
+			sqlCondition, err := cel2sql.ConvertWithSchemas(ast, schemas)
+			require.NoError(t, err)
+
+			t.Logf("CEL Expression: %s", tt.celExpr)
+			t.Logf("Generated SQL WHERE clause: %s", sqlCondition)
+
+			// Try to execute the generated SQL
+			// #nosec G202 - This is a test validating SQL generation, not a security risk
+			query := "SELECT * FROM obj WHERE " + sqlCondition
+			t.Logf("Full SQL Query: %s", query)
+
+			rows, err := db.Query(query)
+			if tt.shouldWork {
+				if err != nil {
+					t.Errorf("❌ Generated SQL failed to execute: %v", err)
+					t.Errorf("   This means the SQL syntax is incorrect for PostgreSQL")
+					t.Errorf("   Expected it to work but got error")
+				} else {
+					defer func() {
+						if closeErr := rows.Close(); closeErr != nil {
+							t.Logf("failed to close rows: %v", closeErr)
+						}
+					}()
+					hasRow := rows.Next()
+					if hasRow {
+						t.Logf("✓ Generated SQL works correctly and returns expected results")
+					} else {
+						t.Errorf("❌ Generated SQL executed but returned no rows (expected 1 row)")
+					}
+				}
+			} else {
+				if err != nil {
+					t.Logf("✓ Generated SQL failed as expected: %v", err)
+				} else {
+					defer func() {
+						if closeErr := rows.Close(); closeErr != nil {
+							t.Logf("failed to close rows: %v", closeErr)
+						}
+					}()
+					t.Errorf("❌ Generated SQL should have failed but succeeded")
+				}
+			}
+		})
+	}
+}

--- a/json_operator_validation_test.go
+++ b/json_operator_validation_test.go
@@ -1,0 +1,142 @@
+package cel2sql_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestPostgreSQLJSONOperatorValidation validates the correct usage of -> vs ->> operators
+// with a real PostgreSQL instance to determine the correct behavior
+func TestPostgreSQLJSONOperatorValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// Start PostgreSQL container
+	req := testcontainers.ContainerRequest{
+		Image:        "postgres:17-alpine",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_PASSWORD": "password",
+			"POSTGRES_DB":       "testdb",
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+	}
+
+	postgresContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err)
+	defer func() {
+		if err := postgresContainer.Terminate(ctx); err != nil {
+			t.Logf("failed to terminate container: %s", err)
+		}
+	}()
+
+	// Get connection string
+	host, err := postgresContainer.Host(ctx)
+	require.NoError(t, err)
+	port, err := postgresContainer.MappedPort(ctx, "5432")
+	require.NoError(t, err)
+
+	connStr := "host=" + host + " port=" + port.Port() + " user=postgres password=password dbname=testdb sslmode=disable"
+	db, err := sql.Open("postgres", connStr)
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Logf("failed to close db: %v", closeErr)
+		}
+	}()
+
+	// Create test table
+	_, err = db.Exec(`CREATE TABLE test_table (id INT, metadata JSONB)`)
+	require.NoError(t, err)
+
+	// Insert test data with nested JSON
+	_, err = db.Exec(`INSERT INTO test_table VALUES (1, '{"user_name": "test", "settings": {"theme": "dark"}}')`)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		query       string
+		shouldWork  bool
+		description string
+	}{
+		{
+			name:        "Correct: table.column->>'field'",
+			query:       "SELECT * FROM test_table WHERE metadata->>'user_name' = 'test'",
+			shouldWork:  true,
+			description: "Standard JSON field extraction from a JSONB column",
+		},
+		{
+			name:        "WRONG: table->>'column'->>'field'",
+			query:       "SELECT * FROM test_table WHERE test_table->>'metadata'->>'user_name' = 'test'",
+			shouldWork:  false,
+			description: "Cannot use ->> on table name - this should fail",
+		},
+		{
+			name:        "Correct nested: table.column->'intermediate'->>'final'",
+			query:       "SELECT * FROM test_table WHERE metadata->'settings'->>'theme' = 'dark'",
+			shouldWork:  true,
+			description: "Use -> for intermediate JSON fields, ->> for final",
+		},
+		{
+			name:        "WRONG nested: table.column->>'intermediate'->>'final'",
+			query:       "SELECT * FROM test_table WHERE metadata->>'settings'->>'theme' = 'dark'",
+			shouldWork:  false,
+			description: "Cannot chain ->> because it returns text",
+		},
+		{
+			name:        "WRONG nested: table->>'column'->'intermediate'->>'final'",
+			query:       "SELECT * FROM test_table WHERE test_table->>'metadata'->'settings'->>'theme' = 'dark'",
+			shouldWork:  false,
+			description: "Cannot use JSON operators on table name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rows, err := db.Query(tt.query)
+			if tt.shouldWork {
+				require.NoError(t, err, "Query should succeed: %s", tt.description)
+				require.NotNil(t, rows)
+				defer func() {
+					if closeErr := rows.Close(); closeErr != nil {
+						t.Logf("failed to close rows: %v", closeErr)
+					}
+				}()
+
+				// Verify we get a result
+				hasRow := rows.Next()
+				require.True(t, hasRow, "Query should return at least one row")
+
+				t.Logf("✓ Query works correctly: %s", tt.query)
+			} else {
+				require.Error(t, err, "Query should fail: %s", tt.description)
+				t.Logf("✓ Query fails as expected: %s", tt.query)
+				t.Logf("  Error: %v", err)
+			}
+		})
+	}
+
+	// Document the findings
+	t.Log("\n=== VALIDATION RESULTS ===")
+	t.Log("For CEL expression: obj.metadata.user_name")
+	t.Log("Where obj is a table with a JSONB column 'metadata'")
+	t.Log("Correct SQL: obj.metadata->>'user_name'")
+	t.Log("NOT: obj->>'metadata'->>'user_name'")
+	t.Log("")
+	t.Log("For CEL expression: obj.metadata.settings.theme")
+	t.Log("Correct SQL: obj.metadata->'settings'->>'theme'")
+	t.Log("NOT: obj->>'metadata'->'settings'->>'theme'")
+	t.Log("NOT: obj.metadata->>'settings'->>'theme'")
+}

--- a/pg/provider.go
+++ b/pg/provider.go
@@ -22,6 +22,7 @@ type FieldSchema struct {
 	Type     string        // PostgreSQL type name (text, integer, boolean, etc.)
 	Repeated bool          // true for arrays
 	Schema   []FieldSchema // for composite types
+	IsJSON   bool          // true for json/jsonb types
 }
 
 // Schema represents a PostgreSQL table schema as a slice of field schemas.
@@ -31,6 +32,7 @@ type Schema []FieldSchema
 type TypeProvider interface {
 	types.Provider
 	LoadTableSchema(ctx context.Context, tableName string) error
+	GetSchemas() map[string]Schema
 	Close()
 }
 
@@ -103,8 +105,9 @@ func (p *typeProvider) LoadTableSchema(ctx context.Context, tableName string) er
 
 		field := FieldSchema{
 			Name:     columnName,
-			Type:     elementType,         // Use element type for arrays, or data_type for non-arrays
-			Repeated: dataType == "ARRAY", // PostgreSQL returns "ARRAY" for array columns
+			Type:     elementType,                                     // Use element type for arrays, or data_type for non-arrays
+			Repeated: dataType == "ARRAY",                             // PostgreSQL returns "ARRAY" for array columns
+			IsJSON:   elementType == "json" || elementType == "jsonb", // Mark JSON/JSONB fields
 		}
 
 		schema = append(schema, field)
@@ -123,6 +126,11 @@ func (p *typeProvider) Close() {
 	if p.pool != nil {
 		p.pool.Close()
 	}
+}
+
+// GetSchemas returns the schema map
+func (p *typeProvider) GetSchemas() map[string]Schema {
+	return p.schemas
 }
 
 func (p *typeProvider) EnumValue(enumName string) ref.Val {


### PR DESCRIPTION
## Summary

Fixes two critical issues with JSON path operator generation:

**Issue #59**: Incorrect operator usage - was applying `->>` to table names
**Issue #20**: Hardcoded JSON field names causing maintainability and security issues

## Problem

### Issue #59: Wrong SQL Generated
```sql
-- CEL: obj.metadata.user_name == "test"
-- Generated (WRONG): obj->>'metadata'->>'user_name' = 'test'
-- Should be:         obj.metadata->>'user_name' = 'test'
```

The code was treating `obj` (the table name) as something that needs JSON operators, when it should recognize `obj.metadata` as a regular table.column reference.

### Issue #20: Hardcoded Field Names
JSON field detection relied on hardcoded lists in 7+ locations:
- Inconsistent across functions
- No way for users to specify their own JSON columns  
- Security risk if fields missed
- Maintenance burden

## Solution

### 1. Schema-Based Type Detection
- Added `IsJSON bool` field to `pg.FieldSchema`
- Created `ConvertWithSchemas(ast, schemas)` function
- Converter now checks schema information to determine if a field is JSON/JSONB
- Falls back to hardcoded lists for backward compatibility

### 2. Fixed table.column Handling  
- Added `getTableAndFieldFromSelectChain()` to identify direct table.column access
- Updated `buildJSONPathInternal()` to render `table.column` correctly before applying JSON operators
- Now properly distinguishes between table references and JSON paths

## Changes

### Core Changes
- **cel2sql.go**: Added `ConvertWithSchemas()`, schema lookup methods, and `schemas` field to converter
- **json.go**: Fixed `shouldUseJSONPath()` and `buildJSONPathInternal()` to use schema information
- **pg/provider.go**: Added `IsJSON` field to `FieldSchema`, `GetSchemas()` method to interface

### Testing
- **json_operator_validation_test.go**: Validates correct operator usage with real PostgreSQL
- **json_integration_validation_test.go**: Verifies generated SQL executes correctly
- Updated all JSON tests to use `ConvertWithSchemas()` and set `IsJSON: true`

## PostgreSQL Validation

Created integration tests using testcontainers with PostgreSQL 17:

✅ **Correct SQL that works:**
```sql
obj.metadata->>'user_name' = 'test'
obj.metadata->'settings'->>'theme' = 'dark'
```

❌ **Wrong SQL that fails:**
```sql
obj->>'metadata'->>'user_name' = 'test'  
-- ERROR: operator does not exist: obj ->> unknown
```

## Backward Compatibility

- `Convert(ast)` still works without schema information
- Falls back to hardcoded field lists when schemas not provided
- All existing tests pass with minimal changes

## Test Results

All tests pass:
```bash
make test
# All tests: PASS
make lint  
# 0 issues
```

## Closes

Closes #59
Addresses #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>