### PR TITLE
fix: Add SQL output length limits to prevent DoS (fixes #33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,6 +386,50 @@ field.matches(r"(((((((((((a"))    // Excessive nesting
 - CPU exhaustion from complex patterns
 - Service disruption from malicious regex
 
+#### Resource Exhaustion Protection
+
+cel2sql includes multiple layers of protection against resource exhaustion attacks (CWE-400):
+
+**Recursion Depth Limits:**
+- **Default limit**: 100 levels of expression nesting
+- **Configurable**: Use `WithMaxDepth()` to adjust
+- **Protection**: Prevents stack overflow from deeply nested expressions (CWE-674)
+
+**SQL Output Length Limits:**
+- **Default limit**: 50,000 characters of generated SQL
+- **Configurable**: Use `WithMaxOutputLength()` to adjust
+- **Protection**: Prevents memory exhaustion from extremely large SQL queries
+
+**Comprehension Depth Limits:**
+- **Fixed limit**: 3 levels of nested comprehensions
+- **Protection**: Prevents resource exhaustion from deeply nested UNNEST/subquery operations
+
+**Examples:**
+```go
+// Use default limits (recommended)
+sql, err := cel2sql.Convert(ast)
+
+// Custom recursion depth limit
+sql, err := cel2sql.Convert(ast,
+    cel2sql.WithMaxDepth(150))
+
+// Custom SQL output length limit
+sql, err := cel2sql.Convert(ast,
+    cel2sql.WithMaxOutputLength(100000))
+
+// Combine multiple limits
+sql, err := cel2sql.Convert(ast,
+    cel2sql.WithMaxDepth(75),
+    cel2sql.WithMaxOutputLength(25000),
+    cel2sql.WithContext(ctx))
+```
+
+**Protection Against:**
+- Stack overflow from deeply nested expressions
+- Memory exhaustion from extremely large SQL output
+- CPU/memory exhaustion from deeply nested comprehensions
+- DoS attacks via resource consumption
+
 #### Context Timeouts
 
 Use context timeouts as defense-in-depth:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ cel2sql includes comprehensive security protections:
 - 🔒 **JSON Field Escaping** - Automatic quote escaping in JSON paths
 - 🚫 **ReDoS Protection** - Validates regex patterns to prevent catastrophic backtracking
 - 🔄 **Recursion Depth Limits** - Prevents stack overflow from deeply nested expressions (default: 100)
+- 📏 **SQL Output Length Limits** - Prevents memory exhaustion from extremely large SQL queries (default: 50,000 chars)
 - ⏱️ **Context Timeouts** - Optional timeout protection for complex expressions
 
 All security features are enabled by default with zero configuration required.

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -43,6 +43,10 @@ const (
 	// maxComprehensionDepth is the maximum nesting depth for CEL comprehensions
 	// to prevent resource exhaustion from deeply nested UNNEST/subquery operations (CWE-400).
 	maxComprehensionDepth = 3
+
+	// defaultMaxSQLOutputLength is the default maximum length of generated SQL output
+	// to prevent resource exhaustion from extremely large SQL queries (CWE-400).
+	defaultMaxSQLOutputLength = 50000
 )
 
 // ConvertOption is a functional option for configuring the Convert function.
@@ -50,10 +54,11 @@ type ConvertOption func(*convertOptions)
 
 // convertOptions holds configuration options for the Convert function.
 type convertOptions struct {
-	schemas  map[string]pg.Schema
-	ctx      context.Context
-	logger   *slog.Logger
-	maxDepth int // Maximum recursion depth (0 = use default)
+	schemas       map[string]pg.Schema
+	ctx           context.Context
+	logger        *slog.Logger
+	maxDepth      int // Maximum recursion depth (0 = use default)
+	maxOutputLen  int // Maximum SQL output length (0 = use default)
 }
 
 // WithSchemas provides schema information for proper JSON/JSONB field handling.
@@ -137,6 +142,26 @@ func WithMaxDepth(maxDepth int) ConvertOption {
 	}
 }
 
+// WithMaxOutputLength sets the maximum length of generated SQL output.
+// If not provided, defaultMaxSQLOutputLength (50000) is used.
+// This protects against resource exhaustion from extremely large SQL queries (CWE-400).
+//
+// Example with custom output length limit:
+//
+//	sql, err := cel2sql.Convert(ast, cel2sql.WithMaxOutputLength(100000))
+//
+// Example with multiple options:
+//
+//	sql, err := cel2sql.Convert(ast,
+//	    cel2sql.WithMaxOutputLength(25000),
+//	    cel2sql.WithMaxDepth(50),
+//	    cel2sql.WithContext(ctx))
+func WithMaxOutputLength(maxLength int) ConvertOption {
+	return func(o *convertOptions) {
+		o.maxOutputLen = maxLength
+	}
+}
+
 // Result represents the output of a CEL to SQL conversion with parameterized queries.
 // It contains the SQL string with placeholders ($1, $2, etc.) and the corresponding parameter values.
 type Result struct {
@@ -158,8 +183,9 @@ func Convert(ast *cel.Ast, opts ...ConvertOption) (string, error) {
 	start := time.Now()
 
 	options := &convertOptions{
-		logger:   slog.New(slog.DiscardHandler), // Default: no-op logger with zero overhead
-		maxDepth: defaultMaxRecursionDepth,      // Default: 100 recursion depth limit
+		logger:       slog.New(slog.DiscardHandler), // Default: no-op logger with zero overhead
+		maxDepth:     defaultMaxRecursionDepth,      // Default: 100 recursion depth limit
+		maxOutputLen: defaultMaxSQLOutputLength,     // Default: 50000 character output limit
 	}
 	for _, opt := range opts {
 		opt(options)
@@ -174,11 +200,12 @@ func Convert(ast *cel.Ast, opts ...ConvertOption) (string, error) {
 	}
 
 	un := &converter{
-		typeMap:  checkedExpr.TypeMap,
-		schemas:  options.schemas,
-		ctx:      options.ctx,
-		logger:   options.logger,
-		maxDepth: options.maxDepth,
+		typeMap:       checkedExpr.TypeMap,
+		schemas:       options.schemas,
+		ctx:           options.ctx,
+		logger:        options.logger,
+		maxDepth:      options.maxDepth,
+		maxOutputLen:  options.maxOutputLen,
 	}
 
 	if err := un.visit(checkedExpr.Expr); err != nil {
@@ -225,8 +252,9 @@ func ConvertParameterized(ast *cel.Ast, opts ...ConvertOption) (*Result, error) 
 	start := time.Now()
 
 	options := &convertOptions{
-		logger:   slog.New(slog.DiscardHandler), // Default: no-op logger with zero overhead
-		maxDepth: defaultMaxRecursionDepth,      // Default: 100 recursion depth limit
+		logger:       slog.New(slog.DiscardHandler), // Default: no-op logger with zero overhead
+		maxDepth:     defaultMaxRecursionDepth,      // Default: 100 recursion depth limit
+		maxOutputLen: defaultMaxSQLOutputLength,     // Default: 50000 character output limit
 	}
 	for _, opt := range opts {
 		opt(options)
@@ -241,12 +269,13 @@ func ConvertParameterized(ast *cel.Ast, opts ...ConvertOption) (*Result, error) 
 	}
 
 	un := &converter{
-		typeMap:      checkedExpr.TypeMap,
-		schemas:      options.schemas,
-		ctx:          options.ctx,
-		logger:       options.logger,
-		maxDepth:     options.maxDepth,
-		parameterize: true, // Enable parameterization
+		typeMap:       checkedExpr.TypeMap,
+		schemas:       options.schemas,
+		ctx:           options.ctx,
+		logger:        options.logger,
+		maxDepth:      options.maxDepth,
+		maxOutputLen:  options.maxOutputLen,
+		parameterize:  true, // Enable parameterization
 	}
 
 	if err := un.visit(checkedExpr.Expr); err != nil {
@@ -278,6 +307,7 @@ type converter struct {
 	logger              *slog.Logger
 	depth               int           // Current recursion depth
 	maxDepth            int           // Maximum allowed recursion depth
+	maxOutputLen        int           // Maximum allowed SQL output length
 	comprehensionDepth  int           // Current comprehension nesting depth
 	parameterize        bool          // Enable parameterized output
 	parameters          []interface{} // Collected parameters for parameterized queries
@@ -311,6 +341,11 @@ func (con *converter) visit(expr *exprpb.Expr) error {
 	// Check for context cancellation at the main recursion entry point
 	if err := con.checkContext(); err != nil {
 		return err
+	}
+
+	// Check SQL output length limit to prevent resource exhaustion (CWE-400)
+	if con.str.Len() > con.maxOutputLen {
+		return fmt.Errorf("generated SQL exceeds maximum output length of %d", con.maxOutputLen)
 	}
 
 	switch expr.ExprKind.(type) {

--- a/output_length_test.go
+++ b/output_length_test.go
@@ -1,0 +1,569 @@
+package cel2sql
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/spandigital/cel2sql/v2/pg"
+	"github.com/stretchr/testify/require"
+)
+
+const testExprXGreaterThanZero = "x > 0"
+
+func TestMaxSQLOutputLength(t *testing.T) {
+	tests := []struct {
+		name         string
+		buildExpr    func() string
+		maxOutputLen int
+		shouldErr    bool
+	}{
+		{
+			name: "within default limit - simple expression",
+			buildExpr: func() string {
+				return "x > 0 && y < 100"
+			},
+			maxOutputLen: 0, // use default (50000)
+			shouldErr:    false,
+		},
+		{
+			name: "within custom limit - small",
+			buildExpr: func() string {
+				return "x == 1"
+			},
+			maxOutputLen: 100,
+			shouldErr:    false,
+		},
+		{
+			name: "exceeds custom limit - moderate expression",
+			buildExpr: func() string {
+				// Build expression that generates ~150 chars of SQL
+				parts := make([]string, 20)
+				for i := range parts {
+					parts[i] = testExprXGreaterThanZero
+				}
+				return strings.Join(parts, " && ")
+			},
+			maxOutputLen: 50, // Very small limit
+			shouldErr:    true,
+		},
+		{
+			name: "large array literal within limit",
+			buildExpr: func() string {
+				// Build array with 100 elements
+				parts := make([]string, 100)
+				for i := range parts {
+					parts[i] = "1"
+				}
+				return "[" + strings.Join(parts, ", ") + "].all(x, x > 0)"
+			},
+			maxOutputLen: 0, // use default
+			shouldErr:    false,
+		},
+		{
+			name: "very large expression exceeds default limit",
+			buildExpr: func() string {
+				// Build expression that will generate >50000 chars
+				// Each repetition adds roughly 10 chars
+				parts := make([]string, 6000)
+				for i := range parts {
+					parts[i] = testExprXGreaterThanZero
+				}
+				return strings.Join(parts, " && ")
+			},
+			maxOutputLen: 0, // use default (50000)
+			shouldErr:    true,
+		},
+		{
+			name: "high custom limit allows large expression",
+			buildExpr: func() string {
+				// Build moderately large expression
+				parts := make([]string, 500)
+				for i := range parts {
+					parts[i] = testExprXGreaterThanZero
+				}
+				return strings.Join(parts, " || ")
+			},
+			maxOutputLen: 100000,
+			shouldErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := pg.Schema{
+				{Name: "x", Type: "integer"},
+				{Name: "y", Type: "integer"},
+			}
+			provider := pg.NewTypeProvider(map[string]pg.Schema{"vars": schema})
+
+			env, err := cel.NewEnv(
+				cel.CustomTypeProvider(provider),
+				cel.Variable("x", cel.IntType),
+				cel.Variable("y", cel.IntType),
+			)
+			require.NoError(t, err)
+
+			expr := tt.buildExpr()
+			ast, issues := env.Compile(expr)
+			require.NoError(t, issues.Err())
+
+			var opts []ConvertOption
+			if tt.maxOutputLen > 0 {
+				opts = append(opts, WithMaxOutputLength(tt.maxOutputLen))
+			}
+
+			sql, err := Convert(ast, opts...)
+
+			if tt.shouldErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "output length")
+			} else {
+				require.NoError(t, err)
+				require.NotEmpty(t, sql)
+			}
+		})
+	}
+}
+
+func TestMaxOutputLengthWithOtherOptions(t *testing.T) {
+	// Test combining WithMaxOutputLength with other options
+	schema := pg.Schema{
+		{Name: "x", Type: "integer"},
+		{Name: "name", Type: "text"},
+	}
+	provider := pg.NewTypeProvider(map[string]pg.Schema{"vars": schema})
+	schemas := provider.GetSchemas()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	env, err := cel.NewEnv(
+		cel.CustomTypeProvider(provider),
+		cel.Variable("x", cel.IntType),
+		cel.Variable("name", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		expr string
+		opts []ConvertOption
+	}{
+		{
+			name: "all options together",
+			expr: "x > 5 && name == 'test'",
+			opts: []ConvertOption{
+				WithMaxOutputLength(10000),
+				WithMaxDepth(50),
+				WithContext(ctx),
+				WithSchemas(schemas),
+				WithLogger(logger),
+			},
+		},
+		{
+			name: "maxOutputLength with context",
+			expr: "x > 10",
+			opts: []ConvertOption{
+				WithMaxOutputLength(5000),
+				WithContext(ctx),
+			},
+		},
+		{
+			name: "maxOutputLength with schemas",
+			expr: "name.contains('foo')",
+			opts: []ConvertOption{
+				WithMaxOutputLength(1000),
+				WithSchemas(schemas),
+			},
+		},
+		{
+			name: "maxOutputLength with maxDepth",
+			expr: "((x + 1) + 2) + 3",
+			opts: []ConvertOption{
+				WithMaxOutputLength(500),
+				WithMaxDepth(100),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			sql, err := Convert(ast, tt.opts...)
+			require.NoError(t, err)
+			require.NotEmpty(t, sql)
+		})
+	}
+}
+
+func TestOutputLengthErrorMessage(t *testing.T) {
+	// Verify error message format
+	schema := pg.Schema{{Name: "x", Type: "integer"}}
+	provider := pg.NewTypeProvider(map[string]pg.Schema{"vars": schema})
+
+	env, err := cel.NewEnv(
+		cel.CustomTypeProvider(provider),
+		cel.Variable("x", cel.IntType),
+	)
+	require.NoError(t, err)
+
+	// Build expression that will exceed limits
+	parts := make([]string, 6000)
+	for i := range parts {
+		parts[i] = testExprXGreaterThanZero
+	}
+	expr := strings.Join(parts, " && ")
+
+	ast, issues := env.Compile(expr)
+	require.NoError(t, issues.Err())
+
+	// Test default error message
+	_, err = Convert(ast)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "generated SQL exceeds maximum output length of 50000")
+
+	// Test custom limit error message
+	_, err = Convert(ast, WithMaxOutputLength(1000))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "generated SQL exceeds maximum output length of 1000")
+}
+
+func TestOutputLengthResetBetweenCalls(t *testing.T) {
+	// Ensure output length check resets between Convert() calls
+	schema := pg.Schema{{Name: "x", Type: "integer"}}
+	provider := pg.NewTypeProvider(map[string]pg.Schema{"vars": schema})
+
+	env, err := cel.NewEnv(
+		cel.CustomTypeProvider(provider),
+		cel.Variable("x", cel.IntType),
+	)
+	require.NoError(t, err)
+
+	// Build expression that's close to but under default limit
+	parts := make([]string, 500)
+	for i := range parts {
+		parts[i] = testExprXGreaterThanZero
+	}
+	expr := strings.Join(parts, " && ")
+
+	ast, issues := env.Compile(expr)
+	require.NoError(t, issues.Err())
+
+	// First conversion should succeed
+	sql1, err := Convert(ast)
+	require.NoError(t, err)
+	require.NotEmpty(t, sql1)
+
+	// Second conversion should also succeed (output was reset)
+	sql2, err := Convert(ast)
+	require.NoError(t, err)
+	require.NotEmpty(t, sql2)
+
+	// Third conversion should also succeed
+	sql3, err := Convert(ast)
+	require.NoError(t, err)
+	require.NotEmpty(t, sql3)
+
+	// All should produce identical output
+	require.Equal(t, sql1, sql2)
+	require.Equal(t, sql2, sql3)
+}
+
+func TestLargeArrayLiterals(t *testing.T) {
+	tests := []struct {
+		name         string
+		arraySize    int
+		maxOutputLen int
+		shouldErr    bool
+	}{
+		{
+			name:         "small array within limit",
+			arraySize:    10,
+			maxOutputLen: 0, // default
+			shouldErr:    false,
+		},
+		{
+			name:         "medium array within limit",
+			arraySize:    100,
+			maxOutputLen: 0, // default
+			shouldErr:    false,
+		},
+		{
+			name:         "large array within limit",
+			arraySize:    1000,
+			maxOutputLen: 0, // default
+			shouldErr:    false,
+		},
+		{
+			name:         "huge array exceeds limit",
+			arraySize:    20000,
+			maxOutputLen: 0, // default (50000)
+			shouldErr:    true,
+		},
+		{
+			name:         "array exceeds custom low limit",
+			arraySize:    50,
+			maxOutputLen: 100,
+			shouldErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := pg.Schema{{Name: "x", Type: "integer"}}
+			provider := pg.NewTypeProvider(map[string]pg.Schema{"vars": schema})
+
+			env, err := cel.NewEnv(
+				cel.CustomTypeProvider(provider),
+				cel.Variable("x", cel.IntType),
+			)
+			require.NoError(t, err)
+
+			// Build array literal
+			parts := make([]string, tt.arraySize)
+			for i := range parts {
+				parts[i] = "1"
+			}
+			expr := "[" + strings.Join(parts, ", ") + "].exists(y, y == 1)"
+
+			ast, issues := env.Compile(expr)
+			require.NoError(t, issues.Err())
+
+			var opts []ConvertOption
+			if tt.maxOutputLen > 0 {
+				opts = append(opts, WithMaxOutputLength(tt.maxOutputLen))
+			}
+
+			_, err = Convert(ast, opts...)
+
+			if tt.shouldErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "output length")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLongStringConcatenations(t *testing.T) {
+	tests := []struct {
+		name         string
+		stringCount  int
+		maxOutputLen int
+		shouldErr    bool
+	}{
+		{
+			name:         "small concatenation",
+			stringCount:  5,
+			maxOutputLen: 0, // default
+			shouldErr:    false,
+		},
+		{
+			name:         "medium concatenation",
+			stringCount:  20,
+			maxOutputLen: 0, // default
+			shouldErr:    false,
+		},
+		{
+			name:         "large concatenation within limit",
+			stringCount:  50,
+			maxOutputLen: 0, // default
+			shouldErr:    false,
+		},
+		{
+			name:         "very large concatenation exceeds default",
+			stringCount:  70,
+			maxOutputLen: 500, // Small limit to trigger error
+			shouldErr:    true,
+		},
+		{
+			name:         "concatenation exceeds custom limit",
+			stringCount:  10,
+			maxOutputLen: 50,
+			shouldErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := pg.Schema{{Name: "s", Type: "text"}}
+			provider := pg.NewTypeProvider(map[string]pg.Schema{"vars": schema})
+
+			env, err := cel.NewEnv(
+				cel.CustomTypeProvider(provider),
+				cel.Variable("s", cel.StringType),
+			)
+			require.NoError(t, err)
+
+			// Build string concatenation expression
+			expr := "s"
+			for i := 0; i < tt.stringCount; i++ {
+				expr += ` + "test"`
+			}
+
+			ast, issues := env.Compile(expr)
+			require.NoError(t, issues.Err())
+
+			var opts []ConvertOption
+			if tt.maxOutputLen > 0 {
+				opts = append(opts, WithMaxOutputLength(tt.maxOutputLen))
+			}
+
+			_, err = Convert(ast, opts...)
+
+			if tt.shouldErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "output length")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMaxOutputLengthWithComprehensions(t *testing.T) {
+	// Test output length limit with comprehensions
+	tests := []struct {
+		name         string
+		expr         string
+		maxOutputLen int
+		shouldErr    bool
+	}{
+		{
+			name:         "simple all comprehension",
+			expr:         "[1, 2, 3].all(x, x > 0)",
+			maxOutputLen: 0, // default
+			shouldErr:    false,
+		},
+		{
+			name:         "simple exists comprehension",
+			expr:         "[1, 2, 3].exists(x, x == 2)",
+			maxOutputLen: 0, // default
+			shouldErr:    false,
+		},
+		{
+			name:         "comprehension with low custom limit",
+			expr:         "[1, 2, 3, 4, 5].filter(x, x > 2)",
+			maxOutputLen: 50,
+			shouldErr:    true,
+		},
+		{
+			name:         "nested comprehension",
+			expr:         "[[1, 2], [3, 4]].all(arr, arr.all(x, x > 0))",
+			maxOutputLen: 0, // default
+			shouldErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := pg.Schema{{Name: "x", Type: "integer"}}
+			provider := pg.NewTypeProvider(map[string]pg.Schema{"vars": schema})
+
+			env, err := cel.NewEnv(
+				cel.CustomTypeProvider(provider),
+				cel.Variable("x", cel.IntType),
+			)
+			require.NoError(t, err)
+
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			var opts []ConvertOption
+			if tt.maxOutputLen > 0 {
+				opts = append(opts, WithMaxOutputLength(tt.maxOutputLen))
+			}
+
+			_, err = Convert(ast, opts...)
+
+			if tt.shouldErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "output length")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParameterizedWithOutputLength(t *testing.T) {
+	// Test that parameterized conversion also respects output length limits
+	schema := pg.Schema{
+		{Name: "x", Type: "integer"},
+		{Name: "name", Type: "text"},
+	}
+	provider := pg.NewTypeProvider(map[string]pg.Schema{"vars": schema})
+	schemas := provider.GetSchemas()
+
+	env, err := cel.NewEnv(
+		cel.CustomTypeProvider(provider),
+		cel.Variable("x", cel.IntType),
+		cel.Variable("name", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		buildExpr    func() string
+		maxOutputLen int
+		shouldErr    bool
+	}{
+		{
+			name: "parameterized within limit",
+			buildExpr: func() string {
+				return `x > 5 && name == "test"`
+			},
+			maxOutputLen: 0,
+			shouldErr:    false,
+		},
+		{
+			name: "parameterized exceeds custom limit",
+			buildExpr: func() string {
+				parts := make([]string, 100)
+				for i := range parts {
+					parts[i] = testExprXGreaterThanZero
+				}
+				return strings.Join(parts, " && ")
+			},
+			maxOutputLen: 100,
+			shouldErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := tt.buildExpr()
+			ast, issues := env.Compile(expr)
+			require.NoError(t, issues.Err())
+
+			var opts []ConvertOption
+			opts = append(opts, WithSchemas(schemas))
+			if tt.maxOutputLen > 0 {
+				opts = append(opts, WithMaxOutputLength(tt.maxOutputLen))
+			}
+
+			result, err := ConvertParameterized(ast, opts...)
+
+			if tt.shouldErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "output length")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.NotEmpty(t, result.SQL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This PR addresses issue #33 by implementing SQL output length limits to prevent Denial of Service attacks through resource exhaustion from extremely large SQL output.

## Changes

### Core Implementation
- **Added `defaultMaxSQLOutputLength = 50000` constant** - Default limit for generated SQL
- **Added `WithMaxOutputLength()` option** - Allows customization of output length limit
- **Implemented output length check in `visit()` method** - Validates SQL length at each recursion point
- **Updated both `Convert()` and `ConvertParameterized()`** - Both respect the output length limit

### Tests (`output_length_test.go`)
Comprehensive test coverage including:
- ✅ Default and custom output length limits
- ✅ Combination with other options (context, schemas, logger, maxDepth)
- ✅ Error message validation
- ✅ Counter reset between calls
- ✅ Large arrays, string concatenations, comprehensions
- ✅ Parameterized query support

### Documentation
- Updated `CLAUDE.md` with new "Resource Exhaustion Protection" section
- Updated `README.md` security features to include SQL output length limits
- Added usage examples for `WithMaxOutputLength()`

## Security Impact
- **Prevents**: DoS attacks via extremely large SQL output
- **Addresses**: CWE-400 (Uncontrolled Resource Consumption)
- **Severity**: Medium (as noted in issue #33)
- **Default Limit**: 50,000 characters (configurable via `WithMaxOutputLength()`)

## Example Usage

```go
// Use default limit (50,000 chars)
sql, err := cel2sql.Convert(ast)

// Custom output length limit
sql, err := cel2sql.Convert(ast,
    cel2sql.WithMaxOutputLength(100000))

// Combine with other options
sql, err := cel2sql.Convert(ast,
    cel2sql.WithMaxOutputLength(25000),
    cel2sql.WithMaxDepth(75),
    cel2sql.WithContext(ctx),
    cel2sql.WithSchemas(schemas))
```

## Testing
- ✅ All tests pass (`make test`)
- ✅ Code passes linting (`make lint`)
- ✅ Coverage maintained at 90%+
- ✅ No breaking changes

## Related Issue
Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>