### PR TITLE
fix: Add array index overflow protection (fixes #19)

### DIFF
--- a/cel2sql.go
+++ b/cel2sql.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1027,7 +1028,14 @@ func (con *converter) visitCallListIndex(expr *exprpb.Expr) error {
 	index := args[1]
 	// PostgreSQL arrays are 1-indexed, CEL is 0-indexed, so add 1
 	if constExpr := index.GetConstExpr(); constExpr != nil {
-		con.str.WriteString(strconv.FormatInt(constExpr.GetInt64Value()+1, 10))
+		idx := constExpr.GetInt64Value()
+		if idx == math.MaxInt64 {
+			return errors.New("array index overflow: cannot convert math.MaxInt64 to 1-based indexing")
+		}
+		if idx < 0 {
+			return fmt.Errorf("invalid negative array index: %d", idx)
+		}
+		con.str.WriteString(strconv.FormatInt(idx+1, 10))
 	} else {
 		if err := con.visit(index); err != nil {
 			return err

--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -223,6 +223,18 @@ func TestConvert(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "array_index_overflow",
+			args:    args{source: `string_list[9223372036854775807]`}, // math.MaxInt64
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "array_index_negative",
+			args:    args{source: `string_list[-1]`},
+			want:    "",
+			wantErr: true,
+		},
+		{
 			name:    "map",
 			args:    args{source: `{"one": 1, "two": 2, "three": 3}["one"] == 1`},
 			want:    "ROW(1, 2, 3).one = 1",


### PR DESCRIPTION
## Summary
Fixes #19 - Array Index Integer Overflow When Converting 0-based to 1-based Indexing

## Problem
When converting CEL's 0-based array indexing to PostgreSQL's 1-based indexing, there was no protection against integer overflow when the index is `math.MaxInt64`. Adding 1 to `math.MaxInt64` (9223372036854775807) causes integer overflow, wrapping to `-9223372036854775808`, which generates invalid SQL with a negative array index.

## Solution
Added overflow protection in `visitCallListIndex()`:
- ✅ Detect `math.MaxInt64` before adding 1 (prevents overflow)
- ✅ Reject negative indices (invalid input)
- ✅ Return clear error messages for both cases

## Changes
- `cel2sql.go`: Added `math` import and overflow validation in `visitCallListIndex()`
- `cel2sql_test.go`: Added test cases for `math.MaxInt64` overflow and negative indices

## Test Results
All tests pass, including new tests:
- ✅ `array_index_overflow` - Verifies `math.MaxInt64` triggers error
- ✅ `array_index_negative` - Verifies negative indices trigger error
- ✅ All existing tests still pass (no regressions)
- ✅ `make lint` passes with 0 issues
- ✅ `make test` passes with full coverage

## Security Impact
- **CWE**: CWE-190 (Integer Overflow)
- **Severity**: Critical
- **Before**: Could generate invalid SQL with negative indices
- **After**: Returns clear error message, preventing invalid SQL generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)