### PR TITLE
fix: Use PostgreSQL hex format for bytea literals (fixes #32)

### DIFF
--- a/cel2sql.go
+++ b/cel2sql.go
@@ -3,6 +3,7 @@ package cel2sql
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -1534,9 +1535,9 @@ func (con *converter) visitConst(expr *exprpb.Expr) error {
 			con.str.WriteString(fmt.Sprintf("$%d", con.paramCount))
 			con.parameters = append(con.parameters, b)
 		} else {
-			con.str.WriteString(`b"`)
-			con.str.WriteString(bytesToOctets(b))
-			con.str.WriteString(`"`)
+			con.str.WriteString("'\\x")
+			con.str.WriteString(hex.EncodeToString(b))
+			con.str.WriteString("'")
 		}
 	default:
 		return newConversionErrorf(errMsgUnsupportedExpression, "constant type: %T", c.ConstantKind)

--- a/edgecase_coverage_test.go
+++ b/edgecase_coverage_test.go
@@ -115,7 +115,7 @@ func TestConstEdgeCases(t *testing.T) {
 		{
 			name:        "bytes_value",
 			expression:  `b"hello" != b""`,
-			expectedSQL: `b"\150\145\154\154\157" != b""`,
+			expectedSQL: `'\x68656c6c6f' != '\x'`,
 			description: "Bytes constant",
 		},
 		{

--- a/final_coverage_test.go
+++ b/final_coverage_test.go
@@ -287,7 +287,7 @@ func TestBinaryOperatorAdditionalCases(t *testing.T) {
 		{
 			name:        "bytes_concatenation",
 			expression:  `b"hello" + b" world" != b""`,
-			expectedSQL: `b"\150\145\154\154\157" || b"\040\167\157\162\154\144" != b""`,
+			expectedSQL: `'\x68656c6c6f' || '\x20776f726c64' != '\x'`,
 			description: "Bytes concatenation with || operator",
 		},
 		{

--- a/utils.go
+++ b/utils.go
@@ -148,18 +148,6 @@ func extractFieldName(node *exprpb.Expr) (string, error) {
 	return fieldName, nil
 }
 
-// Byte conversion utilities
-
-// bytesToOctets converts byte sequences to a string using a three digit octal encoded value
-// per byte.
-func bytesToOctets(byteVal []byte) string {
-	var b strings.Builder
-	for _, c := range byteVal {
-		_, _ = fmt.Fprintf(&b, "\\%03o", c)
-	}
-	return b.String()
-}
-
 // Numeric comparison utilities
 
 // isNumericComparison checks if an operator is a numeric comparison


### PR DESCRIPTION
## Summary

Fixes #32 - Bytea literals now use PostgreSQL-compatible hex format instead of invalid `b"..."` syntax.

## Changes

- **cel2sql.go**: 
  - Added `encoding/hex` import
  - Updated bytea literal generation to use `'\x...'` hex format
- **utils.go**: 
  - Removed unused `bytesToOctets()` function
- **Tests**: 
  - Updated test expectations in `final_coverage_test.go` and `edgecase_coverage_test.go`

## Impact

**High severity fix** - Queries with byte values will now execute successfully instead of failing with syntax errors.

## Before

```go
// Generated invalid SQL
b"\150\145\154\154\157"  // PostgreSQL syntax error
```

## After

```go
// Generates valid PostgreSQL hex format
'\x68656c6c6f'  // Valid PostgreSQL bytea literal
```

## Test plan

- ✅ All existing tests pass
- ✅ Lint checks pass
- ✅ Updated test expectations match new hex format
- ✅ Integration tests verify PostgreSQL compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)