### PR TITLE
fix: Complete RE2 to POSIX regex conversion (fixes #24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,12 +127,26 @@ Full support for CEL comprehensions converted to PostgreSQL UNNEST patterns:
 
 Pattern recognition and conversion logic is in `comprehensions.go`.
 
-### Regex Pattern Matching (v2.8.0)
+### Regex Pattern Matching (v2.8.0+)
 
 Supports CEL `matches()` function with automatic RE2 to POSIX regex conversion:
 - `field.matches(r"pattern")` → `field ~ 'pattern'`
-- `field.matches(r"(?i)pattern")` → `field ~* 'pattern'` (case-insensitive)
-- Automatic conversion of RE2 patterns to PostgreSQL-compatible POSIX format
+- `field.matches(r"(?i)pattern")` → `field ~* 'pattern'` (case-insensitive, `(?i)` stripped from pattern)
+- `field.matches(r"(?:abc)")` → `field ~ '(abc)'` (non-capturing groups converted to regular groups)
+
+**Automatic Conversions:**
+- Case-insensitive flag `(?i)` → Uses `~*` operator, flag stripped from pattern
+- Non-capturing groups `(?:...)` → Converted to regular groups `(...)`
+- Character classes: `\d` → `[[:digit:]]`, `\w` → `[[:alnum:]_]`, `\s` → `[[:space:]]`
+- Word boundaries: `\b` → `\y`
+
+**Unsupported RE2 Features (will return errors):**
+- Lookahead assertions: `(?=...)`, `(?!...)`
+- Lookbehind assertions: `(?<=...)`, `(?<!...)`
+- Named capture groups: `(?P<name>...)`
+- Inline flags other than `(?i)`: `(?m)`, `(?s)`, `(?-i)`, etc.
+
+These validations prevent PostgreSQL syntax errors and ensure predictable behavior.
 
 ## Code Quality Requirements
 

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -839,8 +839,6 @@ func (con *converter) callMatches(target *exprpb.Expr, args []*exprpb.Expr) erro
 		return err
 	}
 
-	con.str.WriteString(" ~ ")
-
 	// Visit the pattern expression and convert from RE2 to POSIX if it's a string literal
 	if constExpr := patternExpr.GetConstExpr(); constExpr != nil && constExpr.GetStringValue() != "" {
 		// Convert RE2 pattern to POSIX
@@ -851,13 +849,10 @@ func (con *converter) callMatches(target *exprpb.Expr, args []*exprpb.Expr) erro
 		}
 
 		// Convert RE2 to POSIX with security validation
-		posixPattern, err := convertRE2ToPOSIX(re2Pattern)
+		posixPattern, caseInsensitive, err := convertRE2ToPOSIX(re2Pattern)
 		if err != nil {
 			return fmt.Errorf("invalid regex pattern: %w", err)
 		}
-
-		// Determine case sensitivity
-		caseInsensitive := strings.HasPrefix(re2Pattern, "(?i)")
 
 		con.logger.LogAttrs(context.Background(), slog.LevelDebug,
 			"regex pattern conversion",
@@ -866,6 +861,13 @@ func (con *converter) callMatches(target *exprpb.Expr, args []*exprpb.Expr) erro
 			slog.Bool("case_insensitive", caseInsensitive),
 		)
 
+		// Use ~* for case-insensitive matching, ~ for case-sensitive
+		if caseInsensitive {
+			con.str.WriteString(" ~* ")
+		} else {
+			con.str.WriteString(" ~ ")
+		}
+
 		// Write the converted pattern as a string literal
 		escaped := strings.ReplaceAll(posixPattern, "'", "''")
 		con.str.WriteString("'")
@@ -873,7 +875,8 @@ func (con *converter) callMatches(target *exprpb.Expr, args []*exprpb.Expr) erro
 		con.str.WriteString("'")
 	} else {
 		// For non-literal patterns, we can't convert at compile time
-		// Just use the pattern as-is and hope it's POSIX compatible
+		// Just use the pattern as-is with case-sensitive operator
+		con.str.WriteString(" ~ ")
 		if err := con.visit(patternExpr); err != nil {
 			return err
 		}
@@ -1947,19 +1950,45 @@ func isBinaryOrTernaryOperator(expr *exprpb.Expr) bool {
 
 // convertRE2ToPOSIX converts an RE2 regex pattern to POSIX ERE format for PostgreSQL.
 // It performs security validation to prevent ReDoS attacks (CWE-1333).
+// Returns: (posixPattern, caseInsensitive, error)
 // Note: This is a basic conversion for common patterns. Full RE2 to POSIX conversion is complex.
-func convertRE2ToPOSIX(re2Pattern string) (string, error) {
+func convertRE2ToPOSIX(re2Pattern string) (string, bool, error) {
 	// 1. Check pattern length to prevent processing extremely long patterns
 	if len(re2Pattern) > maxRegexPatternLength {
-		return "", fmt.Errorf("regex pattern exceeds maximum length of %d characters", maxRegexPatternLength)
+		return "", false, fmt.Errorf("regex pattern exceeds maximum length of %d characters", maxRegexPatternLength)
 	}
 
-	// 2. Detect catastrophic nested quantifiers that cause exponential backtracking
+	// 2. Extract case-insensitive flag if present
+	caseInsensitive := false
+	if strings.HasPrefix(re2Pattern, "(?i)") {
+		caseInsensitive = true
+		re2Pattern = strings.TrimPrefix(re2Pattern, "(?i)")
+	}
+
+	// 3. Detect unsupported RE2 features and return errors
+	// Lookahead assertions
+	if strings.Contains(re2Pattern, "(?=") || strings.Contains(re2Pattern, "(?!") {
+		return "", false, errors.New("lookahead assertions (?=...), (?!...) are not supported in PostgreSQL POSIX regex")
+	}
+	// Lookbehind assertions
+	if strings.Contains(re2Pattern, "(?<=") || strings.Contains(re2Pattern, "(?<!") {
+		return "", false, errors.New("lookbehind assertions (?<=...), (?<!...) are not supported in PostgreSQL POSIX regex")
+	}
+	// Named capture groups
+	if strings.Contains(re2Pattern, "(?P<") {
+		return "", false, errors.New("named capture groups (?P<name>...) are not supported in PostgreSQL POSIX regex")
+	}
+	// Other inline flags (after we've already handled (?i))
+	if strings.Contains(re2Pattern, "(?m") || strings.Contains(re2Pattern, "(?s") || strings.Contains(re2Pattern, "(?-") {
+		return "", false, errors.New("inline flags other than (?i) are not supported in PostgreSQL POSIX regex")
+	}
+
+	// 4. Detect catastrophic nested quantifiers that cause exponential backtracking
 	// Patterns like (a+)+, (a*)*,  (x+x+)+, ((a)+b)+, etc. are extremely dangerous
 
 	// Check for doubled quantifiers
 	if matched, _ := regexp.MatchString(`[*+][*+]`, re2Pattern); matched {
-		return "", errors.New("regex contains catastrophic nested quantifiers that could cause ReDoS")
+		return "", false, errors.New("regex contains catastrophic nested quantifiers that could cause ReDoS")
 	}
 
 	// Check for groups that contain quantifiers and are themselves quantified
@@ -1990,7 +2019,7 @@ func convertRE2ToPOSIX(re2Pattern string) (string, error) {
 					if nextChar == '*' || nextChar == '+' || nextChar == '?' || nextChar == '{' {
 						// This group is quantified. Check if it contains quantifiers
 						if len(groupHasQuantifier) > 0 && groupHasQuantifier[len(groupHasQuantifier)-1] {
-							return "", errors.New("regex contains catastrophic nested quantifiers that could cause ReDoS")
+							return "", false, errors.New("regex contains catastrophic nested quantifiers that could cause ReDoS")
 						}
 					}
 				}
@@ -2018,21 +2047,21 @@ func convertRE2ToPOSIX(re2Pattern string) (string, error) {
 		}
 	}
 
-	// 3. Count and limit capture groups to prevent memory exhaustion
+	// 5. Count and limit capture groups to prevent memory exhaustion
 	groupCount := strings.Count(re2Pattern, "(") - strings.Count(re2Pattern, `\(`)
 	if groupCount > maxRegexGroups {
-		return "", fmt.Errorf("regex contains %d capture groups, exceeds maximum of %d", groupCount, maxRegexGroups)
+		return "", false, fmt.Errorf("regex contains %d capture groups, exceeds maximum of %d", groupCount, maxRegexGroups)
 	}
 
-	// 4. Detect exponential alternation patterns like (a|a)*b or (a|ab)*
+	// 6. Detect exponential alternation patterns like (a|a)*b or (a|ab)*
 	alternationPattern := regexp.MustCompile(`\([^)]*\|[^)]*\)[*+]`)
 	if alternationPattern.MatchString(re2Pattern) {
 		// Check if alternation has overlapping branches (more dangerous)
 		// This is a simple heuristic - full analysis would be more complex
-		return "", errors.New("regex contains quantified alternation that could cause ReDoS")
+		return "", false, errors.New("regex contains quantified alternation that could cause ReDoS")
 	}
 
-	// 5. Check nesting depth to prevent deeply nested patterns
+	// 7. Check nesting depth to prevent deeply nested patterns
 	maxDepth := 0
 	currentDepth := 0
 	for _, char := range re2Pattern {
@@ -2046,7 +2075,7 @@ func convertRE2ToPOSIX(re2Pattern string) (string, error) {
 		}
 	}
 	if maxDepth > maxRegexNestingDepth {
-		return "", fmt.Errorf("regex nesting depth %d exceeds maximum of %d", maxDepth, maxRegexNestingDepth)
+		return "", false, fmt.Errorf("regex nesting depth %d exceeds maximum of %d", maxDepth, maxRegexNestingDepth)
 	}
 
 	// Passed all security checks - proceed with conversion
@@ -2080,16 +2109,19 @@ func convertRE2ToPOSIX(re2Pattern string) (string, error) {
 	// 8. Non-whitespace shortcuts: \S -> [^[:space:]]
 	posixPattern = strings.ReplaceAll(posixPattern, `\S`, `[^[:space:]]`)
 
-	// Note: Many RE2 features are not directly convertible to POSIX ERE:
-	// - Lookahead/lookbehind assertions (?=...), (?!...), (?<=...), (?<!...)
-	// - Non-capturing groups (?:...)
-	// - Named groups (?P<name>...)
-	// - Case-insensitive flags (?i)
-	// - Multiline flags (?m)
-	// - Unicode character classes
-	//
-	// For these cases, the pattern is returned as-is, which may cause PostgreSQL errors
-	// if the pattern uses unsupported RE2 features.
+	// 9. Non-capturing groups: (?:...) -> (...)
+	//    POSIX ERE doesn't have non-capturing groups, so convert to regular groups
+	posixPattern = strings.ReplaceAll(posixPattern, `(?:`, `(`)
 
-	return posixPattern, nil
+	// Note: Unsupported RE2 features that are now validated and return errors:
+	// - Lookahead/lookbehind assertions (?=...), (?!...), (?<=...), (?<!...) - ERROR
+	// - Named groups (?P<name>...) - ERROR
+	// - Case-insensitive flag (?i) - CONVERTED (returned as separate boolean)
+	// - Other inline flags (?m), (?s) - ERROR
+	//
+	// Converted features:
+	// - Non-capturing groups (?:...) - Converted to regular groups (...)
+	// - Character class shortcuts (\d, \w, \s, etc.) - Converted to POSIX equivalents
+
+	return posixPattern, caseInsensitive, nil
 }

--- a/parameterized_test.go
+++ b/parameterized_test.go
@@ -1,6 +1,7 @@
 package cel2sql_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -434,9 +435,10 @@ func TestConvertParameterized_RegexPatterns(t *testing.T) {
 			// Assert parameter count
 			assert.Len(t, result.Parameters, tt.wantParamCount, "Parameter count should match")
 
-			// Assert SQL contains regex operator
+			// Assert SQL contains regex operator (~ or ~* for case-insensitive)
 			if tt.containsRegex {
-				assert.Contains(t, result.SQL, " ~ ", "SQL should contain regex operator")
+				hasRegexOperator := strings.Contains(result.SQL, " ~ ") || strings.Contains(result.SQL, " ~* ")
+				assert.True(t, hasRegexOperator, "SQL should contain regex operator (~ or ~*)")
 			}
 		})
 	}

--- a/regex_conversion_test.go
+++ b/regex_conversion_test.go
@@ -1,0 +1,321 @@
+package cel2sql_test
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spandigital/cel2sql/v2"
+)
+
+// TestRegexConversion_CaseInsensitive tests that (?i) flag generates ~* operator
+func TestRegexConversion_CaseInsensitive(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Variable("email", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		celExpr      string
+		wantOperator string
+		wantPattern  string
+	}{
+		{
+			name:         "case_insensitive_simple",
+			celExpr:      `email.matches(r"(?i)test@example\.com")`,
+			wantOperator: "~*",
+			wantPattern:  "test@example\\.com",
+		},
+		{
+			name:         "case_insensitive_complex",
+			celExpr:      `email.matches(r"(?i)[a-z]+@[a-z]+\.[a-z]+")`,
+			wantOperator: "~*",
+			wantPattern:  "[a-z]+@[a-z]+\\.[a-z]+",
+		},
+		{
+			name:         "case_sensitive_default",
+			celExpr:      `email.matches(r"test@example\.com")`,
+			wantOperator: "~",
+			wantPattern:  "test@example\\.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.celExpr)
+			require.NoError(t, issues.Err())
+
+			sql, err := cel2sql.Convert(ast)
+			require.NoError(t, err)
+
+			// Check that the correct operator is used
+			assert.Contains(t, sql, tt.wantOperator, "SQL should contain operator %s", tt.wantOperator)
+
+			// Check that (?i) is stripped from the pattern
+			assert.NotContains(t, sql, "(?i)", "Pattern should not contain (?i) flag")
+
+			// Check that the pattern is present
+			assert.Contains(t, sql, tt.wantPattern, "SQL should contain pattern %s", tt.wantPattern)
+		})
+	}
+}
+
+// TestRegexConversion_NonCapturingGroups tests that (?:...) is converted to (...)
+func TestRegexConversion_NonCapturingGroups(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Variable("text", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		celExpr     string
+		wantPattern string
+	}{
+		{
+			name:        "simple_non_capturing_group",
+			celExpr:     `text.matches(r"(?:abc)")`,
+			wantPattern: "(abc)",
+		},
+		{
+			name:        "non_capturing_with_alternation",
+			celExpr:     `text.matches(r"(?:cat|dog)")`,
+			wantPattern: "(cat|dog)",
+		},
+		{
+			name:        "nested_non_capturing",
+			celExpr:     `text.matches(r"(?:(?:a|b)c)")`,
+			wantPattern: "((a|b)c)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.celExpr)
+			require.NoError(t, issues.Err())
+
+			sql, err := cel2sql.Convert(ast)
+			require.NoError(t, err)
+
+			// Check that (?:) is converted to (
+			assert.NotContains(t, sql, "(?:", "Pattern should not contain (?:")
+			assert.Contains(t, sql, tt.wantPattern, "SQL should contain converted pattern %s", tt.wantPattern)
+		})
+	}
+}
+
+// TestRegexConversion_UnsupportedFeatures tests that unsupported features return errors
+func TestRegexConversion_UnsupportedFeatures(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Variable("text", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		pattern       string
+		wantErrorText string
+	}{
+		{
+			name:          "lookahead_positive",
+			pattern:       `test(?=ing)`,
+			wantErrorText: "lookahead assertions",
+		},
+		{
+			name:          "lookahead_negative",
+			pattern:       `test(?!ing)`,
+			wantErrorText: "lookahead assertions",
+		},
+		{
+			name:          "lookbehind_positive",
+			pattern:       `(?<=pre)test`,
+			wantErrorText: "lookbehind assertions",
+		},
+		{
+			name:          "lookbehind_negative",
+			pattern:       `(?<!pre)test`,
+			wantErrorText: "lookbehind assertions",
+		},
+		{
+			name:          "named_group",
+			pattern:       `(?P<name>[a-z]+)`,
+			wantErrorText: "named capture groups",
+		},
+		{
+			name:          "multiline_flag",
+			pattern:       `(?m)^test$`,
+			wantErrorText: "inline flags other than",
+		},
+		{
+			name:          "dotall_flag",
+			pattern:       `(?s)test.+`,
+			wantErrorText: "inline flags other than",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			celExpr := `text.matches(r"` + tt.pattern + `")`
+			ast, issues := env.Compile(celExpr)
+			require.NoError(t, issues.Err(), "CEL should compile")
+
+			// Conversion should fail with clear error
+			sql, err := cel2sql.Convert(ast)
+			require.Error(t, err, "Should reject unsupported pattern: %s", tt.pattern)
+			assert.Empty(t, sql)
+			assert.Contains(t, err.Error(), tt.wantErrorText, "Error should mention %s", tt.wantErrorText)
+		})
+	}
+}
+
+// TestRegexConversion_CharacterClasses tests that character classes are converted correctly
+func TestRegexConversion_CharacterClasses(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Variable("text", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		celPattern   string
+		wantContains string
+	}{
+		{
+			name:         "digit_class",
+			celPattern:   `\d+`,
+			wantContains: "[[:digit:]]",
+		},
+		{
+			name:         "word_class",
+			celPattern:   `\w+`,
+			wantContains: "[[:alnum:]_]",
+		},
+		{
+			name:         "whitespace_class",
+			celPattern:   `\s+`,
+			wantContains: "[[:space:]]",
+		},
+		{
+			name:         "non_digit_class",
+			celPattern:   `\D+`,
+			wantContains: "[^[:digit:]]",
+		},
+		{
+			name:         "non_word_class",
+			celPattern:   `\W+`,
+			wantContains: "[^[:alnum:]_]",
+		},
+		{
+			name:         "non_whitespace_class",
+			celPattern:   `\S+`,
+			wantContains: "[^[:space:]]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			celExpr := `text.matches(r"` + tt.celPattern + `")`
+			ast, issues := env.Compile(celExpr)
+			require.NoError(t, issues.Err())
+
+			sql, err := cel2sql.Convert(ast)
+			require.NoError(t, err)
+			assert.Contains(t, sql, tt.wantContains, "SQL should contain converted character class")
+		})
+	}
+}
+
+// TestRegexConversion_CombinedFeatures tests combining multiple conversion features
+func TestRegexConversion_CombinedFeatures(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Variable("email", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		celExpr      string
+		wantOperator string
+		wantContains []string
+		notContains  []string
+	}{
+		{
+			name:         "case_insensitive_with_non_capturing",
+			celExpr:      `email.matches(r"(?i)(?:admin|user)@\w+\.com")`,
+			wantOperator: "~*",
+			wantContains: []string{"(admin|user)", "[[:alnum:]_]+"},
+			notContains:  []string{"(?i)", "(?:"},
+		},
+		{
+			name:         "case_insensitive_with_char_classes",
+			celExpr:      `email.matches(r"(?i)\w+@\w+\.\w+")`,
+			wantOperator: "~*",
+			wantContains: []string{"[[:alnum:]_]+"},
+			notContains:  []string{"(?i)", `\w`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.celExpr)
+			require.NoError(t, issues.Err())
+
+			sql, err := cel2sql.Convert(ast)
+			require.NoError(t, err)
+
+			assert.Contains(t, sql, tt.wantOperator, "SQL should use operator %s", tt.wantOperator)
+
+			for _, want := range tt.wantContains {
+				assert.Contains(t, sql, want, "SQL should contain %s", want)
+			}
+
+			for _, notWant := range tt.notContains {
+				assert.NotContains(t, sql, notWant, "SQL should not contain %s", notWant)
+			}
+		})
+	}
+}
+
+// TestRegexConversion_BackwardCompatibility tests that existing patterns still work
+func TestRegexConversion_BackwardCompatibility(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.Variable("email", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		celExpr string
+	}{
+		{
+			name:    "simple_literal",
+			celExpr: `email.matches(r"test@example.com")`,
+		},
+		{
+			name:    "with_anchors",
+			celExpr: `email.matches(r"^[a-z]+@[a-z]+\.[a-z]+$")`,
+		},
+		{
+			name:    "with_quantifiers",
+			celExpr: `email.matches(r"[a-z]{3,10}@[a-z]+\.com")`,
+		},
+		{
+			name:    "with_alternation",
+			celExpr: `email.matches(r"(admin|user)@example\.com")`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.celExpr)
+			require.NoError(t, issues.Err())
+
+			sql, err := cel2sql.Convert(ast)
+			require.NoError(t, err)
+			assert.NotEmpty(t, sql, "Should generate valid SQL")
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #24 - Completes the RE2 to POSIX regex conversion by properly handling case-insensitive flag, converting non-capturing groups, and validating unsupported features.

## Problem
Previously, the RE2 to POSIX conversion was incomplete:
- ❌ `(?i)` flag was detected but not used - patterns still used `~` instead of `~*`
- ❌ Non-capturing groups `(?:...)` were not converted - caused PostgreSQL errors
- ❌ Unsupported features (lookahead, lookbehind, named groups) silently passed through - caused runtime failures

## Solution

### 1. Case-Insensitive Flag Handling
**Modified `convertRE2ToPOSIX()` signature:**
```go
func convertRE2ToPOSIX(re2Pattern string) (string, bool, error)
```

- Extracts and strips `(?i)` flag from pattern
- Returns `caseInsensitive` boolean
- Updated `callMatches()` to use `~*` when `caseInsensitive == true`

**Before:**
```cel
field.matches(r"(?i)test")  →  field ~ '(?i)test'  // ❌ Wrong operator, flag not stripped
```

**After:**
```cel
field.matches(r"(?i)test")  →  field ~* 'test'     // ✅ Correct operator, flag stripped
```

### 2. Non-Capturing Groups Conversion
Added automatic conversion of `(?:...)` to `(...)`:
```cel
field.matches(r"(?:cat|dog)")  →  field ~ '(cat|dog)'  // ✅ PostgreSQL compatible
```

### 3. Validation for Unsupported Features
Now returns clear errors instead of silently passing through:

**Lookahead/Lookbehind:**
```cel
field.matches(r"test(?=ing)")  →  Error: "lookahead assertions (?=...), (?!...) are not supported"
```

**Named Groups:**
```cel
field.matches(r"(?P<name>[a-z]+)")  →  Error: "named capture groups (?P<name>...) are not supported"
```

**Other Inline Flags:**
```cel
field.matches(r"(?m)^test$")  →  Error: "inline flags other than (?i) are not supported"
```

### 4. Comprehensive Testing
Added `regex_conversion_test.go` with 6 test functions covering:
- ✅ Case-insensitive flag handling (3 test cases)
- ✅ Non-capturing group conversion (3 test cases)
- ✅ Unsupported feature validation (7 test cases)
- ✅ Character class conversions (6 test cases)
- ✅ Combined features (2 test cases)
- ✅ Backward compatibility (4 test cases)

### 5. Updated Documentation
**CLAUDE.md** now clearly documents:
- Automatic conversions that happen
- Unsupported features that return errors
- Examples of each conversion

## Testing
- ✅ All new tests pass (25+ test cases)
- ✅ All existing tests pass (updated 1 test for new behavior)
- ✅ `make lint` passes with 0 issues
- ✅ `make test` passes completely

## Breaking Change ⚠️
Patterns using unsupported RE2 features now return clear errors at conversion time instead of silently passing through and causing PostgreSQL syntax errors at runtime.

**Migration:** Review regex patterns and ensure they don't use lookahead, lookbehind, named groups, or flags other than `(?i)`. Most common patterns are unaffected.

## Examples

### Case-Insensitive Matching
```go
// CEL
email.matches(r"(?i)[a-z]+@[a-z]+\.[a-z]+")

// Generated SQL (NEW)
email ~* '[a-z]+@[a-z]+\.[a-z]+'

// Previously generated (WRONG)
email ~ '(?i)[a-z]+@[a-z]+\.[a-z]+'
```

### Non-Capturing Groups
```go
// CEL
text.matches(r"(?:admin|user)@example\.com")

// Generated SQL (NEW)
text ~ '(admin|user)@example\.com'

// Previously generated (CAUSED ERRORS)
text ~ '(?:admin|user)@example\.com'
```

### Error on Unsupported Features
```go
// CEL
text.matches(r"test(?=ing)")

// Result (NEW)
Error: "lookahead assertions (?=...), (?!...) are not supported in PostgreSQL POSIX regex"

// Previously (WRONG)
text ~ 'test(?=ing)'  // PostgreSQL syntax error at runtime
```

## Checklist
- [x] Code follows project conventions
- [x] Comprehensive tests added (25+ test cases)
- [x] Documentation updated
- [x] All tests passing
- [x] Linting passes
- [x] Breaking change documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)