### PR TITLE
fix: Use correct AT TIME ZONE syntax in EXTRACT (fixes #41)

### DIFF
--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -387,7 +387,7 @@ func TestConvert(t *testing.T) {
 		{
 			name:    "\"timestamp_getHours_withTimezone",
 			args:    args{source: `created_at.getHours("Asia/Tokyo")`},
-			want:    "EXTRACT(HOUR FROM created_at AT 'Asia/Tokyo')",
+			want:    "EXTRACT(HOUR FROM created_at AT TIME ZONE 'Asia/Tokyo')",
 			wantErr: false,
 		},
 		{

--- a/timestamps.go
+++ b/timestamps.go
@@ -164,7 +164,7 @@ func (con *converter) callExtractFromTimestamp(function string, target *exprpb.E
 		return err
 	}
 	if isTimestampType(con.getType(target)) && len(args) == 1 {
-		con.str.WriteString(" AT ")
+		con.str.WriteString(" AT TIME ZONE ")
 		if err := con.visit(args[0]); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Fixes #41 - SQL syntax error in timestamp EXTRACT function when used with timezone conversions.

## Problem

The code was generating invalid PostgreSQL syntax by using `AT` instead of `AT TIME ZONE` when extracting time components from a timestamp with a timezone argument.

**Invalid SQL (before):**
```sql
EXTRACT(HOUR FROM timestamp AT 'America/New_York')
```

**Valid SQL (after):**
```sql
EXTRACT(HOUR FROM timestamp AT TIME ZONE 'America/New_York')
```

## Changes

- **timestamps.go:167** - Changed `" AT "` to `" AT TIME ZONE "`
- **cel2sql_test.go:390** - Updated test expectation to match correct PostgreSQL syntax

## Testing

- ✅ `make fmt` - Code formatted
- ✅ `make lint` - No issues (0 issues)
- ✅ `make test` - All tests pass with race detection enabled

## Impact

Low-risk fix that corrects SQL syntax to match PostgreSQL standards. The `AT TIME ZONE` operator is the correct PostgreSQL syntax for timezone conversion within EXTRACT operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)