### PR TITLE
fix: Validate database connection on pool creation (fixes #45)

### DIFF
--- a/pg/provider.go
+++ b/pg/provider.go
@@ -127,6 +127,13 @@ func NewTypeProviderWithConnection(ctx context.Context, connectionString string)
 		return nil, errors.New("failed to create connection pool")
 	}
 
+	// Validate connection works immediately rather than on first query
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		// Security: Same sanitized error approach as above
+		return nil, errors.New("failed to connect to database")
+	}
+
 	return &typeProvider{
 		schemas: make(map[string]Schema),
 		pool:    pool,


### PR DESCRIPTION
## Summary

- Add immediate connection validation with `Ping()` in `NewTypeProviderWithConnection` (pg/provider.go:130-135)
- Catch connection errors early rather than deferring them to the first query
- Properly close the pool before returning error if ping fails
- Use same sanitized error approach for security (avoid exposing connection details)

## Changes

The fix adds connection validation immediately after creating the connection pool:
```go
if err := pool.Ping(ctx); err != nil {
    pool.Close()
    return nil, errors.New("failed to connect to database")
}
```

This ensures that connection issues are detected immediately during `NewTypeProviderWithConnection()` rather than on the first database query, providing better error visibility and user experience.

## Test plan

- [x] Linting passes (`make lint`)
- [x] All existing tests pass (`make test`)
- [x] Code follows existing security patterns (sanitized error messages)
- [x] Proper resource cleanup (pool.Close() on error)

**Manual testing recommended:**
- Test with invalid connection string
- Test with unreachable database server
- Test with valid connection (existing integration tests cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)