### PR TITLE
feat: backport features and fix from observeinc/cel2sql fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## [Unreleased]
 
 ### Added
+- **WithJSONVariables option** — declare CEL variable names that map to flat JSONB
+  columns so `context.host == "x"` produces `context->>'host' = 'x'` without a parent
+  table struct. Both dot notation (`tags.color`) and bracket notation (`tags["color"]`)
+  are supported. Backported from observeinc/cel2sql fork.
+- **WithColumnAliases option** — map CEL variable names to different SQL column names
+  (e.g., `name` → `usr_name`). Combines with `WithJSONVariables` for aliased JSONB
+  columns. Alias values are validated via the dialect's field name validator.
+  Backported from observeinc/cel2sql fork.
+- **WithParamStartIndex option** — for `ConvertParameterized`, set the first
+  placeholder index (e.g., `WithParamStartIndex(5)` produces `$5, $6, ...`). Useful
+  when embedding the CEL fragment in a larger parameterized query. Values less than 1
+  clamp to 1. Backported from observeinc/cel2sql fork PR #2.
 - **Multi-Dialect SQL Support**
   - Introduced `Dialect` interface for pluggable SQL generation (`dialect/dialect.go`)
   - PostgreSQL dialect extracted from converter into `dialect/postgres/` (zero behavior change)
@@ -15,6 +27,15 @@
   - Dialect-agnostic schema types in `schema/` package
   - Shared test case infrastructure (`testcases/`, `testutil/`) with per-dialect expected SQL
   - Dialect registry for name-based lookup (`dialect.Register()`, `dialect.Get()`)
+
+### Changed
+- **BREAKING: Removed name-based numeric-cast heuristic in `visitIdent`** —
+  identifiers named `score`, `value`, `num`, `amount`, `count`, or `level` are no
+  longer auto-cast to `::numeric`. The heuristic was a footgun that incorrectly cast
+  plain (non-JSON) variables that happened to share these names. Numeric casting is
+  now driven solely by JSON text-extraction context (handled in `visitCall`). Callers
+  that relied on the implicit cast should add an explicit cast in CEL or use the
+  JSON comprehension paths. Backported from observeinc/cel2sql fork PR #1.
 
 ## [3.5.0] - 2026-01-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,6 +441,55 @@ sqlCondition, err := cel2sql.Convert(ast)
 // Returns: table.field = 'value' AND table.age > 30
 ```
 
+### Flat JSONB Variables with WithJSONVariables
+
+Declare CEL variables that map to flat JSONB columns. Both `tags.color` and
+`tags["color"]` produce JSONB text-extraction operators instead of plain dot notation.
+
+```go
+result, err := cel2sql.ConvertParameterized(ast,
+    cel2sql.WithJSONVariables("tags", "metadata"))
+// CEL: tags.color == "blue" && metadata.source == "api"
+// SQL: tags->>'color' = $1 AND metadata->>'source' = $2
+```
+
+Without `WithJSONVariables`, JSONB detection still works through the existing
+`table.jsonColumn.key` pattern when schemas are provided.
+
+### Column Aliasing with WithColumnAliases
+
+Map CEL variable names to different SQL column names — useful when DB columns
+use prefixed names (`usr_name`) but expressions use clean names (`name`). Alias
+values are validated through the dialect's field-name validator.
+
+```go
+result, err := cel2sql.ConvertParameterized(ast,
+    cel2sql.WithColumnAliases(map[string]string{
+        "name":   "usr_name",
+        "active": "usr_active",
+    }))
+// CEL: name == "Alice" && active == true
+// SQL: usr_name = $1 AND usr_active IS TRUE
+```
+
+Combines with `WithJSONVariables` so aliased JSONB columns produce correctly
+prefixed operators (e.g., `tbl_tags->>'color'`).
+
+### Embedding Parameterized CEL SQL with WithParamStartIndex
+
+When embedding a CEL fragment inside a larger parameterized query, set the
+first placeholder index so it doesn't collide with existing parameters. Values
+less than 1 clamp to 1.
+
+```go
+// Caller already has $1..$4 in their outer query
+result, err := cel2sql.ConvertParameterized(ast,
+    cel2sql.WithParamStartIndex(5))
+// CEL: name == "Alice" && age > 30
+// SQL: name = $5 AND age > $6
+// Caller appends result.Parameters to their args at positions 5, 6
+```
+
 ### Query Analysis and Index Recommendations
 
 cel2sql can analyze CEL expressions and recommend **dialect-specific** database indexes to optimize performance.

--- a/README.md
+++ b/README.md
@@ -123,9 +123,13 @@ sql, err := cel2sql.Convert(ast,
 **Available Options:**
 - `WithDialect(dialect.Dialect)` - Select target SQL dialect (default: PostgreSQL)
 - `WithSchemas(map[string]pg.Schema)` - Provide table schemas for JSON detection
+- `WithJSONVariables(vars ...string)` - Declare CEL variables that map to flat JSONB columns
+- `WithColumnAliases(map[string]string)` - Map CEL variable names to different SQL column names
 - `WithContext(context.Context)` - Enable cancellation and timeouts
 - `WithLogger(*slog.Logger)` - Enable structured logging
 - `WithMaxDepth(int)` - Set custom recursion depth limit (default: 100)
+- `WithMaxOutputLength(int)` - Set custom SQL output length limit (default: 50000)
+- `WithParamStartIndex(int)` - First placeholder index for `ConvertParameterized` (default: 1)
 
 ## Multi-Dialect Support
 

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -51,14 +51,15 @@ type ConvertOption func(*convertOptions)
 
 // convertOptions holds configuration options for the Convert function.
 type convertOptions struct {
-	schemas      map[string]schema.Schema
-	jsonVars     map[string]bool   // Variable names that are JSONB columns
-	columnAlias  map[string]string // CEL variable name → SQL column name
-	ctx          context.Context
-	logger       *slog.Logger
-	maxDepth     int             // Maximum recursion depth (0 = use default)
-	maxOutputLen int             // Maximum SQL output length (0 = use default)
-	dialect      dialect.Dialect // SQL dialect (nil = PostgreSQL default)
+	schemas         map[string]schema.Schema
+	jsonVars        map[string]bool   // Variable names that are JSONB columns
+	columnAlias     map[string]string // CEL variable name → SQL column name
+	ctx             context.Context
+	logger          *slog.Logger
+	maxDepth        int             // Maximum recursion depth (0 = use default)
+	maxOutputLen    int             // Maximum SQL output length (0 = use default)
+	dialect         dialect.Dialect // SQL dialect (nil = PostgreSQL default)
+	paramStartIndex int             // First placeholder index for ConvertParameterized (1 = $1; 0 means default 1)
 }
 
 // WithDialect sets the SQL dialect for conversion.
@@ -219,6 +220,19 @@ func WithMaxOutputLength(maxLength int) ConvertOption {
 	}
 }
 
+// WithParamStartIndex sets the first placeholder index for ConvertParameterized.
+// Use this when embedding the CEL fragment into a larger parameterized query so
+// placeholders don't clash with existing parameters. Default is 1 ($1, $2, ...).
+// Values less than 1 are clamped to 1.
+//
+// Example: WithParamStartIndex(5) produces $5, $6, ...; the caller appends
+// result.Parameters to their args at the corresponding positions.
+func WithParamStartIndex(index int) ConvertOption {
+	return func(o *convertOptions) {
+		o.paramStartIndex = index
+	}
+}
+
 // Result represents the output of a CEL to SQL conversion with parameterized queries.
 // It contains the SQL string with placeholders ($1, $2, etc.) and the corresponding parameter values.
 type Result struct {
@@ -343,6 +357,10 @@ func ConvertParameterized(ast *cel.Ast, opts ...ConvertOption) (*Result, error) 
 		return nil, err
 	}
 
+	paramStart := options.paramStartIndex
+	if paramStart < 1 {
+		paramStart = 1
+	}
 	un := &converter{
 		typeMap:      checkedExpr.TypeMap,
 		schemas:      options.schemas,
@@ -353,7 +371,8 @@ func ConvertParameterized(ast *cel.Ast, opts ...ConvertOption) (*Result, error) 
 		dialect:      options.dialect,
 		maxDepth:     options.maxDepth,
 		maxOutputLen: options.maxOutputLen,
-		parameterize: true, // Enable parameterization
+		parameterize: true,           // Enable parameterization
+		paramCount:   paramStart - 1, // First placeholder will be paramStart after first increment
 	}
 
 	if err := un.visit(checkedExpr.Expr); err != nil {

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -52,6 +52,7 @@ type ConvertOption func(*convertOptions)
 // convertOptions holds configuration options for the Convert function.
 type convertOptions struct {
 	schemas      map[string]schema.Schema
+	jsonVars     map[string]bool // Variable names that are JSONB columns
 	ctx          context.Context
 	logger       *slog.Logger
 	maxDepth     int             // Maximum recursion depth (0 = use default)
@@ -83,6 +84,28 @@ func WithDialect(d dialect.Dialect) ConvertOption {
 func WithSchemas(schemas map[string]schema.Schema) ConvertOption {
 	return func(o *convertOptions) {
 		o.schemas = schemas
+	}
+}
+
+// WithJSONVariables declares CEL variable names that correspond to JSONB columns.
+// When a variable is marked as JSONB, field access via dot notation (context.host)
+// and bracket notation (context["host"]) will produce PostgreSQL JSONB operators
+// (e.g., context->>'host') instead of plain dot notation (context.host).
+//
+// Example:
+//
+//	result, err := cel2sql.ConvertParameterized(ast,
+//	    cel2sql.WithJSONVariables("context"))
+//	// CEL: context.host == "web-1"
+//	// SQL: context->>'host' = $1
+func WithJSONVariables(vars ...string) ConvertOption {
+	return func(o *convertOptions) {
+		if o.jsonVars == nil {
+			o.jsonVars = make(map[string]bool, len(vars))
+		}
+		for _, v := range vars {
+			o.jsonVars[v] = true
+		}
 	}
 }
 
@@ -223,6 +246,7 @@ func Convert(ast *cel.Ast, opts ...ConvertOption) (string, error) {
 	un := &converter{
 		typeMap:      checkedExpr.TypeMap,
 		schemas:      options.schemas,
+		jsonVars:     options.jsonVars,
 		ctx:          options.ctx,
 		logger:       options.logger,
 		dialect:      options.dialect,
@@ -299,6 +323,7 @@ func ConvertParameterized(ast *cel.Ast, opts ...ConvertOption) (*Result, error) 
 	un := &converter{
 		typeMap:      checkedExpr.TypeMap,
 		schemas:      options.schemas,
+		jsonVars:     options.jsonVars,
 		ctx:          options.ctx,
 		logger:       options.logger,
 		dialect:      options.dialect,
@@ -332,6 +357,7 @@ type converter struct {
 	str                strings.Builder
 	typeMap            map[int64]*exprpb.Type
 	schemas            map[string]schema.Schema
+	jsonVars           map[string]bool // Variable names that are JSONB columns
 	ctx                context.Context
 	logger             *slog.Logger
 	dialect            dialect.Dialect
@@ -1880,12 +1906,18 @@ func (con *converter) visitCallMapIndex(expr *exprpb.Expr) error {
 		return fmt.Errorf("%w: map index operator requires map and key arguments", ErrInvalidArguments)
 	}
 	m := args[0]
-	nested := isBinaryOrTernaryOperator(m)
-	if err := con.visitMaybeNested(m, nested); err != nil {
-		return err
-	}
 	fieldName, err := extractFieldName(args[1])
 	if err != nil {
+		return err
+	}
+	if identExpr := m.GetIdentExpr(); identExpr != nil && con.isJSONVariable(identExpr.GetName()) {
+		if err := con.visit(m); err != nil {
+			return err
+		}
+		return con.dialect.WriteJSONFieldAccess(&con.str, func() error { return nil }, fieldName, true)
+	}
+	nested := isBinaryOrTernaryOperator(m)
+	if err := con.visitMaybeNested(m, nested); err != nil {
 		return err
 	}
 	con.str.WriteString(".")

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -405,14 +405,13 @@ type converter struct {
 	ctx                context.Context
 	logger             *slog.Logger
 	dialect            dialect.Dialect
-	depth              int             // Current recursion depth
-	maxDepth           int             // Maximum allowed recursion depth
-	maxOutputLen       int             // Maximum allowed SQL output length
-	comprehensionDepth int             // Current comprehension nesting depth
-	jsonIterVars       map[string]bool // Iteration variables from JSON array comprehensions
-	parameterize       bool            // Enable parameterized output
-	parameters         []any           // Collected parameters for parameterized queries
-	paramCount         int             // Parameter counter for placeholders
+	depth              int   // Current recursion depth
+	maxDepth           int   // Maximum allowed recursion depth
+	maxOutputLen       int   // Maximum allowed SQL output length
+	comprehensionDepth int   // Current comprehension nesting depth
+	parameterize       bool  // Enable parameterized output
+	parameters         []any // Collected parameters for parameterized queries
+	paramCount         int   // Parameter counter for placeholders
 }
 
 // checkContext checks if the context has been cancelled or expired.
@@ -1956,10 +1955,7 @@ func (con *converter) visitCallMapIndex(expr *exprpb.Expr) error {
 		return err
 	}
 	if identExpr := m.GetIdentExpr(); identExpr != nil && con.isJSONVariable(identExpr.GetName()) {
-		if err := con.visit(m); err != nil {
-			return err
-		}
-		return con.dialect.WriteJSONFieldAccess(&con.str, func() error { return nil }, fieldName, true)
+		return con.dialect.WriteJSONFieldAccess(&con.str, func() error { return con.visit(m) }, fieldName, true)
 	}
 	nested := isBinaryOrTernaryOperator(m)
 	if err := con.visitMaybeNested(m, nested); err != nil {
@@ -2351,15 +2347,7 @@ func (con *converter) visitIdent(expr *exprpb.Expr) error {
 		sqlName = alias
 	}
 
-	// Check if this identifier needs numeric casting for JSON comprehensions
-	if con.needsNumericCasting(identName) {
-		con.str.WriteString("(")
-		con.str.WriteString(sqlName)
-		con.str.WriteString(")")
-		con.dialect.WriteCastToNumeric(&con.str)
-	} else {
-		con.str.WriteString(sqlName)
-	}
+	con.str.WriteString(sqlName)
 	return nil
 }
 

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -386,13 +386,14 @@ type converter struct {
 	ctx                context.Context
 	logger             *slog.Logger
 	dialect            dialect.Dialect
-	depth              int   // Current recursion depth
-	maxDepth           int   // Maximum allowed recursion depth
-	maxOutputLen       int   // Maximum allowed SQL output length
-	comprehensionDepth int   // Current comprehension nesting depth
-	parameterize       bool  // Enable parameterized output
-	parameters         []any // Collected parameters for parameterized queries
-	paramCount         int   // Parameter counter for placeholders
+	depth              int             // Current recursion depth
+	maxDepth           int             // Maximum allowed recursion depth
+	maxOutputLen       int             // Maximum allowed SQL output length
+	comprehensionDepth int             // Current comprehension nesting depth
+	jsonIterVars       map[string]bool // Iteration variables from JSON array comprehensions
+	parameterize       bool            // Enable parameterized output
+	parameters         []any           // Collected parameters for parameterized queries
+	paramCount         int             // Parameter counter for placeholders
 }
 
 // checkContext checks if the context has been cancelled or expired.

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -52,7 +52,8 @@ type ConvertOption func(*convertOptions)
 // convertOptions holds configuration options for the Convert function.
 type convertOptions struct {
 	schemas      map[string]schema.Schema
-	jsonVars     map[string]bool // Variable names that are JSONB columns
+	jsonVars     map[string]bool   // Variable names that are JSONB columns
+	columnAlias  map[string]string // CEL variable name → SQL column name
 	ctx          context.Context
 	logger       *slog.Logger
 	maxDepth     int             // Maximum recursion depth (0 = use default)
@@ -106,6 +107,27 @@ func WithJSONVariables(vars ...string) ConvertOption {
 		for _, v := range vars {
 			o.jsonVars[v] = true
 		}
+	}
+}
+
+// WithColumnAliases maps CEL variable names to SQL column names.
+// When a CEL identifier matches a key in the alias map, the SQL output
+// uses the mapped column name instead. This is useful when the database
+// column names differ from the user-facing CEL variable names (e.g.,
+// prefixed column names in views or tables).
+//
+// Example:
+//
+//	result, err := cel2sql.ConvertParameterized(ast,
+//	    cel2sql.WithColumnAliases(map[string]string{
+//	        "name":   "usr_name",
+//	        "active": "usr_active",
+//	    }))
+//	// CEL: name == "Alice"
+//	// SQL: usr_name = $1
+func WithColumnAliases(aliases map[string]string) ConvertOption {
+	return func(o *convertOptions) {
+		o.columnAlias = aliases
 	}
 }
 
@@ -247,6 +269,7 @@ func Convert(ast *cel.Ast, opts ...ConvertOption) (string, error) {
 		typeMap:      checkedExpr.TypeMap,
 		schemas:      options.schemas,
 		jsonVars:     options.jsonVars,
+		columnAlias:  options.columnAlias,
 		ctx:          options.ctx,
 		logger:       options.logger,
 		dialect:      options.dialect,
@@ -324,6 +347,7 @@ func ConvertParameterized(ast *cel.Ast, opts ...ConvertOption) (*Result, error) 
 		typeMap:      checkedExpr.TypeMap,
 		schemas:      options.schemas,
 		jsonVars:     options.jsonVars,
+		columnAlias:  options.columnAlias,
 		ctx:          options.ctx,
 		logger:       options.logger,
 		dialect:      options.dialect,
@@ -357,7 +381,8 @@ type converter struct {
 	str                strings.Builder
 	typeMap            map[int64]*exprpb.Type
 	schemas            map[string]schema.Schema
-	jsonVars           map[string]bool // Variable names that are JSONB columns
+	jsonVars           map[string]bool   // Variable names that are JSONB columns
+	columnAlias        map[string]string // CEL variable name → SQL column name
 	ctx                context.Context
 	logger             *slog.Logger
 	dialect            dialect.Dialect
@@ -2297,14 +2322,23 @@ func (con *converter) visitIdent(expr *exprpb.Expr) error {
 		return fmt.Errorf("%w: %w", ErrInvalidFieldName, err)
 	}
 
+	// Apply column alias if configured
+	sqlName := identName
+	if alias, ok := con.columnAlias[identName]; ok {
+		if err := con.dialect.ValidateFieldName(alias); err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidFieldName, err)
+		}
+		sqlName = alias
+	}
+
 	// Check if this identifier needs numeric casting for JSON comprehensions
 	if con.needsNumericCasting(identName) {
 		con.str.WriteString("(")
-		con.str.WriteString(identName)
+		con.str.WriteString(sqlName)
 		con.str.WriteString(")")
 		con.dialect.WriteCastToNumeric(&con.str)
 	} else {
-		con.str.WriteString(identName)
+		con.str.WriteString(sqlName)
 	}
 	return nil
 }

--- a/json.go
+++ b/json.go
@@ -17,9 +17,17 @@ const (
 	jsonbArrayElementsText = "jsonb_array_elements_text"
 )
 
-// shouldUseJSONPath determines if we should use JSON path operators for field access
-// This function checks if the operand represents a JSON/JSONB field using schema information
+// shouldUseJSONPath determines if we should use JSON path operators for field access.
+// This function checks if the operand represents a JSON/JSONB field using schema
+// information or the WithJSONVariables option for flat JSONB variables.
 func (con *converter) shouldUseJSONPath(operand *exprpb.Expr, _ string) bool {
+	// Check if the operand is a flat variable declared as JSONB via WithJSONVariables
+	if identExpr := operand.GetIdentExpr(); identExpr != nil {
+		if con.isJSONVariable(identExpr.GetName()) {
+			return true
+		}
+	}
+
 	// Check if the operand is a direct table.column access where column is JSON
 	if selectExpr := operand.GetSelectExpr(); selectExpr != nil {
 		// For obj.metadata, check if metadata is a JSON column in obj table
@@ -43,6 +51,11 @@ func (con *converter) shouldUseJSONPath(operand *exprpb.Expr, _ string) bool {
 	}
 
 	return false
+}
+
+// isJSONVariable checks if a variable name was declared as JSONB via WithJSONVariables.
+func (con *converter) isJSONVariable(name string) bool {
+	return con.jsonVars != nil && con.jsonVars[name]
 }
 
 // hasJSONFieldInChain checks if there's a JSON field anywhere in the select expression chain

--- a/json.go
+++ b/json.go
@@ -40,7 +40,14 @@ func (con *converter) shouldUseJSONPath(operand *exprpb.Expr, _ string) bool {
 				slog.String("field", fieldName),
 				slog.Bool("is_json", isJSON),
 			)
-			return isJSON
+			if isJSON {
+				return true
+			}
+			// If the root identifier is a JSONB variable (WithJSONVariables),
+			// the whole chain should use JSON operators.
+			if con.isJSONVariable(tableName) {
+				return true
+			}
 		}
 
 		// Check if there's a JSON field somewhere in the operand chain
@@ -70,6 +77,11 @@ func (con *converter) hasJSONFieldInChain(expr *exprpb.Expr) bool {
 			if con.isFieldJSON(tableName, field) {
 				return true
 			}
+			// Check if the root identifier was declared as a JSON variable
+			// via WithJSONVariables (e.g., tags.corpus.section).
+			if con.isJSONVariable(tableName) {
+				return true
+			}
 		}
 
 		// Recursively check the operand
@@ -92,14 +104,6 @@ func (con *converter) isJSONTextExtraction(expr *exprpb.Expr) bool {
 	}
 
 	return false
-}
-
-// needsNumericCasting checks if an identifier is an iteration variable from a
-// JSON array comprehension that requires numeric casting. Returns true only for
-// variables explicitly registered in jsonIterVars during comprehension processing,
-// not based on variable name heuristics.
-func (con *converter) needsNumericCasting(identName string) bool {
-	return con.jsonIterVars != nil && con.jsonIterVars[identName]
 }
 
 // isNumericJSONField checks if a JSON field name typically contains numeric values
@@ -305,8 +309,10 @@ func (con *converter) buildJSONPathInternal(expr *exprpb.Expr, isFinalField bool
 	// Check if the operand is also a select expression (nested access)
 	if operandSelect := operand.GetSelectExpr(); operandSelect != nil {
 		// Check if this is a direct table.column access (e.g., obj.metadata)
-		// If so, we should NOT apply JSON operators to this level
-		if tableName, columnName, ok := con.getTableAndFieldFromSelectChain(operand); ok {
+		// If so, we should NOT apply JSON operators to this level.
+		// Skip this shortcut when the root is a flat JSONB variable (WithJSONVariables);
+		// those should produce JSON operators all the way down (tags->'corpus'->>'section').
+		if tableName, columnName, ok := con.getTableAndFieldFromSelectChain(operand); ok && !con.isJSONVariable(tableName) {
 			// This is table.column where column is JSON/JSONB
 			// Render as table.column without JSON operators, then add JSON operator for the current field
 			return con.dialect.WriteJSONFieldAccess(&con.str, func() error {

--- a/json.go
+++ b/json.go
@@ -94,12 +94,12 @@ func (con *converter) isJSONTextExtraction(expr *exprpb.Expr) bool {
 	return false
 }
 
-// needsNumericCasting checks if an identifier represents a numeric iteration variable from JSON
+// needsNumericCasting checks if an identifier is an iteration variable from a
+// JSON array comprehension that requires numeric casting. Returns true only for
+// variables explicitly registered in jsonIterVars during comprehension processing,
+// not based on variable name heuristics.
 func (con *converter) needsNumericCasting(identName string) bool {
-	// Common iteration variable names that come from numeric JSON arrays
-	numericIterationVars := []string{"score", "value", "num", "amount", "count", "level"}
-
-	return slices.Contains(numericIterationVars, identName)
+	return con.jsonIterVars != nil && con.jsonIterVars[identName]
 }
 
 // isNumericJSONField checks if a JSON field name typically contains numeric values

--- a/json_variables_test.go
+++ b/json_variables_test.go
@@ -78,7 +78,9 @@ func TestWithJSONVariables_DotNotation(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantSQL, result.SQL)
-			if tt.wantArgs != nil {
+			if tt.wantArgs == nil {
+				assert.Empty(t, result.Parameters, "expected no parameters")
+			} else {
 				assert.Equal(t, tt.wantArgs, result.Parameters)
 			}
 		})
@@ -121,7 +123,9 @@ func TestWithJSONVariables_BracketNotation(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantSQL, result.SQL)
-			if tt.wantArgs != nil {
+			if tt.wantArgs == nil {
+				assert.Empty(t, result.Parameters, "expected no parameters")
+			} else {
 				assert.Equal(t, tt.wantArgs, result.Parameters)
 			}
 		})
@@ -176,6 +180,47 @@ func TestWithJSONVariables_NonParameterized(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, `props->>'key' = 'value'`, sql)
+}
+
+func TestWithJSONVariables_NestedDotNotation(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("tags", cel.MapType(cel.StringType, cel.DynType)),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		expr     string
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "two levels",
+			expr:     `tags.corpus.section == "intro"`,
+			wantSQL:  `tags->'corpus'->>'section' = $1`,
+			wantArgs: []any{"intro"},
+		},
+		{
+			name:     "three levels",
+			expr:     `tags.corpus.section.subsection == "x"`,
+			wantSQL:  `tags->'corpus'->'section'->>'subsection' = $1`,
+			wantArgs: []any{"x"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithJSONVariables("tags"))
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantSQL, result.SQL)
+			assert.Equal(t, tt.wantArgs, result.Parameters)
+		})
+	}
 }
 
 func TestWithJSONVariables_OnlyDeclaredVarsAffected(t *testing.T) {
@@ -249,7 +294,9 @@ func TestWithColumnAliases(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantSQL, result.SQL)
-			if tt.wantArgs != nil {
+			if tt.wantArgs == nil {
+				assert.Empty(t, result.Parameters, "expected no parameters")
+			} else {
 				assert.Equal(t, tt.wantArgs, result.Parameters)
 			}
 		})

--- a/json_variables_test.go
+++ b/json_variables_test.go
@@ -1,0 +1,197 @@
+package cel2sql_test
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spandigital/cel2sql/v3"
+)
+
+func TestWithJSONVariables_DotNotation(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("status", cel.StringType),
+		cel.Variable("tags", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		expr     string
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "equality",
+			expr:     `tags.color == "blue"`,
+			wantSQL:  `tags->>'color' = $1`,
+			wantArgs: []any{"blue"},
+		},
+		{
+			name:     "not equal",
+			expr:     `tags.color != "red"`,
+			wantSQL:  `tags->>'color' != $1`,
+			wantArgs: []any{"red"},
+		},
+		{
+			name:     "contains",
+			expr:     `tags.color.contains("lu")`,
+			wantSQL:  `POSITION($1 IN tags->>'color') > 0`,
+			wantArgs: []any{"lu"},
+		},
+		{
+			name:     "startsWith",
+			expr:     `tags.color.startsWith("bl")`,
+			wantSQL:  `tags->>'color' LIKE 'bl%' ESCAPE E'\\'`,
+			wantArgs: nil,
+		},
+		{
+			name:     "endsWith",
+			expr:     `tags.color.endsWith("ue")`,
+			wantSQL:  `tags->>'color' LIKE '%ue' ESCAPE E'\\'`,
+			wantArgs: nil,
+		},
+		{
+			name:     "combined with flat variable",
+			expr:     `status == "ok" && tags.color == "blue"`,
+			wantSQL:  `status = $1 AND tags->>'color' = $2`,
+			wantArgs: []any{"ok", "blue"},
+		},
+		{
+			name:     "multiple keys",
+			expr:     `tags.color == "blue" && tags.shape == "circle"`,
+			wantSQL:  `tags->>'color' = $1 AND tags->>'shape' = $2`,
+			wantArgs: []any{"blue", "circle"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithJSONVariables("tags"))
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantSQL, result.SQL)
+			if tt.wantArgs != nil {
+				assert.Equal(t, tt.wantArgs, result.Parameters)
+			}
+		})
+	}
+}
+
+func TestWithJSONVariables_BracketNotation(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("metadata", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		expr     string
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "equality",
+			expr:     `metadata["key"] == "value"`,
+			wantSQL:  `metadata->>'key' = $1`,
+			wantArgs: []any{"value"},
+		},
+		{
+			name:     "contains",
+			expr:     `metadata["key"].contains("val")`,
+			wantSQL:  `POSITION($1 IN metadata->>'key') > 0`,
+			wantArgs: []any{"val"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithJSONVariables("metadata"))
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantSQL, result.SQL)
+			if tt.wantArgs != nil {
+				assert.Equal(t, tt.wantArgs, result.Parameters)
+			}
+		})
+	}
+}
+
+func TestWithJSONVariables_MultipleVariables(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("tags", cel.MapType(cel.StringType, cel.StringType)),
+		cel.Variable("metadata", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`tags.color == "blue" && metadata.source == "api"`)
+	require.NoError(t, issues.Err())
+
+	result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithJSONVariables("tags", "metadata"))
+	require.NoError(t, err)
+
+	assert.Equal(t, `tags->>'color' = $1 AND metadata->>'source' = $2`, result.SQL)
+	assert.Equal(t, []any{"blue", "api"}, result.Parameters)
+}
+
+func TestWithJSONVariables_BackwardCompatible(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("data", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`data.key == "value"`)
+	require.NoError(t, issues.Err())
+
+	result, err := cel2sql.ConvertParameterized(ast)
+	require.NoError(t, err)
+
+	assert.Equal(t, `data.key = $1`, result.SQL, "without WithJSONVariables, should produce dot notation")
+}
+
+func TestWithJSONVariables_NonParameterized(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("props", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`props.key == "value"`)
+	require.NoError(t, issues.Err())
+
+	sql, err := cel2sql.Convert(ast, cel2sql.WithJSONVariables("props"))
+	require.NoError(t, err)
+
+	assert.Equal(t, `props->>'key' = 'value'`, sql)
+}
+
+func TestWithJSONVariables_OnlyDeclaredVarsAffected(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("tags", cel.MapType(cel.StringType, cel.StringType)),
+		cel.Variable("other", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`tags.color == "blue" && other.key == "val"`)
+	require.NoError(t, issues.Err())
+
+	result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithJSONVariables("tags"))
+	require.NoError(t, err)
+
+	assert.Equal(t, `tags->>'color' = $1 AND other.key = $2`, result.SQL,
+		"only 'tags' should use JSONB operators; 'other' should use dot notation")
+}

--- a/json_variables_test.go
+++ b/json_variables_test.go
@@ -195,3 +195,103 @@ func TestWithJSONVariables_OnlyDeclaredVarsAffected(t *testing.T) {
 	assert.Equal(t, `tags->>'color' = $1 AND other.key = $2`, result.SQL,
 		"only 'tags' should use JSONB operators; 'other' should use dot notation")
 }
+
+func TestWithColumnAliases(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("name", cel.StringType),
+		cel.Variable("active", cel.BoolType),
+	)
+	require.NoError(t, err)
+
+	aliases := map[string]string{
+		"name":   "tbl_name",
+		"active": "tbl_active",
+	}
+
+	tests := []struct {
+		name     string
+		expr     string
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "simple equality",
+			expr:     `name == "Alice"`,
+			wantSQL:  `tbl_name = $1`,
+			wantArgs: []any{"Alice"},
+		},
+		{
+			name:    "boolean",
+			expr:    `active == true`,
+			wantSQL: `tbl_active IS TRUE`,
+		},
+		{
+			name:     "string contains",
+			expr:     `name.contains("li")`,
+			wantSQL:  `POSITION($1 IN tbl_name) > 0`,
+			wantArgs: []any{"li"},
+		},
+		{
+			name:     "combined",
+			expr:     `name == "Alice" && active == true`,
+			wantSQL:  `tbl_name = $1 AND tbl_active IS TRUE`,
+			wantArgs: []any{"Alice"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithColumnAliases(aliases))
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantSQL, result.SQL)
+			if tt.wantArgs != nil {
+				assert.Equal(t, tt.wantArgs, result.Parameters)
+			}
+		})
+	}
+}
+
+func TestWithColumnAliases_CombinedWithJSONVariables(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("status", cel.StringType),
+		cel.Variable("tags", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`status == "ok" && tags.color == "blue"`)
+	require.NoError(t, issues.Err())
+
+	result, err := cel2sql.ConvertParameterized(ast,
+		cel2sql.WithColumnAliases(map[string]string{
+			"status": "tbl_status",
+			"tags":   "tbl_tags",
+		}),
+		cel2sql.WithJSONVariables("tags"),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, `tbl_status = $1 AND tbl_tags->>'color' = $2`, result.SQL)
+	assert.Equal(t, []any{"ok", "blue"}, result.Parameters)
+}
+
+func TestWithColumnAliases_BackwardCompatible(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("name", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`name == "Alice"`)
+	require.NoError(t, issues.Err())
+
+	result, err := cel2sql.ConvertParameterized(ast)
+	require.NoError(t, err)
+
+	assert.Equal(t, `name = $1`, result.SQL, "without WithColumnAliases, should use original name")
+}

--- a/param_start_index_test.go
+++ b/param_start_index_test.go
@@ -1,0 +1,117 @@
+package cel2sql_test
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spandigital/cel2sql/v3"
+)
+
+func TestWithParamStartIndex_Default(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("name", cel.StringType),
+		cel.Variable("age", cel.IntType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`name == "Alice" && age > 30`)
+	require.NoError(t, issues.Err())
+
+	result, err := cel2sql.ConvertParameterized(ast)
+	require.NoError(t, err)
+
+	assert.Equal(t, `name = $1 AND age > $2`, result.SQL)
+	assert.Equal(t, []any{"Alice", int64(30)}, result.Parameters)
+}
+
+func TestWithParamStartIndex_ExplicitOne(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("name", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`name == "Alice"`)
+	require.NoError(t, issues.Err())
+
+	result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithParamStartIndex(1))
+	require.NoError(t, err)
+
+	assert.Equal(t, `name = $1`, result.SQL, "WithParamStartIndex(1) is identical to default")
+	assert.Equal(t, []any{"Alice"}, result.Parameters)
+}
+
+func TestWithParamStartIndex_Five(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("name", cel.StringType),
+		cel.Variable("age", cel.IntType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`name == "Alice" && age > 30`)
+	require.NoError(t, issues.Err())
+
+	result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithParamStartIndex(5))
+	require.NoError(t, err)
+
+	assert.Equal(t, `name = $5 AND age > $6`, result.SQL,
+		"placeholders should start at $5 and continue $6, $7, ...")
+	assert.Equal(t, []any{"Alice", int64(30)}, result.Parameters,
+		"Parameters slice contents and length are unchanged regardless of start index")
+}
+
+func TestWithParamStartIndex_ClampToOne(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("name", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`name == "Alice"`)
+	require.NoError(t, issues.Err())
+
+	tests := []struct {
+		name  string
+		index int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"large negative", -100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithParamStartIndex(tt.index))
+			require.NoError(t, err)
+
+			assert.Equal(t, `name = $1`, result.SQL, "values < 1 should clamp to 1")
+			assert.Equal(t, []any{"Alice"}, result.Parameters)
+		})
+	}
+}
+
+func TestWithParamStartIndex_ManyParams(t *testing.T) {
+	env, err := cel.NewEnv(
+		cel.CustomTypeAdapter(types.DefaultTypeAdapter),
+		cel.Variable("a", cel.StringType),
+		cel.Variable("b", cel.StringType),
+		cel.Variable("c", cel.StringType),
+		cel.Variable("d", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`a == "1" && b == "2" && c == "3" && d == "4"`)
+	require.NoError(t, issues.Err())
+
+	result, err := cel2sql.ConvertParameterized(ast, cel2sql.WithParamStartIndex(10))
+	require.NoError(t, err)
+
+	assert.Equal(t, `a = $10 AND b = $11 AND c = $12 AND d = $13`, result.SQL)
+	assert.Equal(t, []any{"1", "2", "3", "4"}, result.Parameters)
+}


### PR DESCRIPTION
## Summary

Backports four commits from the [observeinc/cel2sql](https://github.com/observeinc/cel2sql) fork — three additive options plus one bug fix. Skips the fork's module-path rename commit. All commits attribute the original author via `Co-Authored-By`.

- **`WithJSONVariables(vars ...string)`** — declare flat JSONB variables; `tags.color` (or `tags["color"]`) emits `tags->>'color'`. Previously cel2sql only recognized JSONB through the two-level `table.jsonColumn.key` pattern.
- **`WithColumnAliases(map[string]string)`** — map CEL variable names to different SQL columns (e.g., `name` → `usr_name`). Aliases are validated through the dialect's field-name validator. Combines with `WithJSONVariables`.
- **`WithParamStartIndex(int)`** — first placeholder index for `ConvertParameterized` (e.g., `$5, $6, ...`). Useful when embedding the CEL fragment inside a larger parameterized query. Values < 1 clamp to 1.
- **BREAKING fix**: removed the name-based numeric-cast heuristic from `visitIdent`. Identifiers named `score`/`value`/`num`/`amount`/`count`/`level` are no longer auto-cast to `::numeric` — the heuristic was a footgun that misfired on plain (non-JSON) variables sharing those names. JSON text-extraction comparisons in `visitCall` are unaffected.

## Notes

- Dropped the fork's unused `markJSONIterVar`/`unmarkJSONIterVar` helpers per the project's "no scaffolding for hypothetical futures" guidance — the empty `jsonIterVars` map already produces the intended "heuristic disabled" behavior.
- Added 5 tests for `WithParamStartIndex` (the fork's PR shipped without any).
- All `Co-Authored-By:` trailers attribute `david.lotfi <david.lotfi@observeinc.com>`.

## Test plan

- [x] `golangci-lint run` — 0 issues
- [x] `go test -short -race ./...` — all unit tests pass (15 new, all existing). `TestPostgreSQL17Compatibility` fails locally due to a missing Docker daemon; this is pre-existing on `main` and unrelated.
- [ ] CI green
- [ ] `make ci` on a Docker-enabled host (full integration suite)

## Commits

- `feat: add WithJSONVariables option for flat JSONB variable support`
- `feat: add WithColumnAliases option for CEL-to-SQL column name mapping`
- `fix: remove name-based numeric casting heuristic from visitIdent`
- `feat: add WithParamStartIndex for embedding CEL SQL in larger queries`
- `docs: document backported observe options + breaking change`

🤖 Generated with [Claude Code](https://claude.com/claude-code)