### PR TITLE
test: stop t.Log triggering false GitHub Actions error annotations

### DIFF
--- a/json_escaping_test.go
+++ b/json_escaping_test.go
@@ -129,11 +129,11 @@ func TestEscapeJSONFieldNameFunction(t *testing.T) {
 	t.Log("Example: \"user's name\" -> \"user''s name\"")
 	t.Log("This prevents SQL injection when field names contain single quotes")
 	t.Log("The function is used in:")
-	t.Log("  - cel2sql.go: visitSelect() for -> and ->> operators")
-	t.Log("  - cel2sql.go: visitHasFunction() for ? and -> operators")
-	t.Log("  - cel2sql.go: visitNestedJSONHas() for jsonb_extract_path_text()")
-	t.Log("  - json.go: buildJSONPathForArray() for nested JSON paths")
-	t.Log("  - json.go: buildJSONPathInternal() for all JSON path construction")
+	t.Log("  - cel2sql.go — visitSelect() for -> and ->> operators")
+	t.Log("  - cel2sql.go — visitHasFunction() for ? and -> operators")
+	t.Log("  - cel2sql.go — visitNestedJSONHas() for jsonb_extract_path_text()")
+	t.Log("  - json.go — buildJSONPathForArray() for nested JSON paths")
+	t.Log("  - json.go — buildJSONPathInternal() for all JSON path construction")
 }
 
 // TestJSONFieldNameEscaping_SecurityImplications tests security aspects


### PR DESCRIPTION
## Summary

The [v3.7.0 Release run](https://github.com/SPANDigital/cel2sql/actions/runs/24983713042) succeeded but reported five `##[error]` annotations like:

> X buildJSONPathInternal() for all JSON path construction
> X visitNestedJSONHas() for jsonb_extract_path_text()
> X visitSelect() for -> and ->> operators

These come from `TestEscapeJSONFieldNameFunction` in `json_escaping_test.go`. The test prints documentation lines via `t.Log`:

```go
t.Log("  - cel2sql.go: visitSelect() for -> and ->> operators")
```

When `go test -v` runs, this becomes:
```
    json_escaping_test.go:132:   - cel2sql.go: visitSelect() for -> and ->> operators
```

The Go problem matcher in GitHub Actions matches the inner `cel2sql.go: …` against `<file>:<line>:<col>` and emits `##[error]` annotations on green runs.

Fix: replace the colon after the filename with an em-dash (`—`). Same readability, breaks the false match. No behavior change.

## Test plan

- [x] `go test -v -run "TestEscapeJSONFieldNameFunction|TestJSONFieldNameEscaping_SecurityImplications"` — both pass
- [ ] CI green and no `##[error]` annotations on this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)