### PR TITLE
feat: add Apache Spark SQL dialect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-cel2sql converts CEL (Common Expression Language) expressions to SQL conditions. It supports multiple SQL dialects: PostgreSQL (default), MySQL, SQLite, DuckDB, and BigQuery.
+cel2sql converts CEL (Common Expression Language) expressions to SQL conditions. It supports six SQL dialects: PostgreSQL (default), MySQL, SQLite, DuckDB, BigQuery, and Apache Spark SQL.
 
 **Module**: `github.com/spandigital/cel2sql/v3`
-**Go Version**: 1.24+
-**Current Version**: v3.0.0
+**Go Version**: 1.25+
+**Current Version**: v3.7.1
 
 ## Common Development Commands
 
@@ -94,7 +94,13 @@ go test -v -run TestFunctionName ./...
     - Handles nested RECORD types recursively
     - Accepts `*bigquery.Client` + dataset ID
 
-11. **`sqltypes/types.go`** - Custom SQL type definitions for CEL (DATE, TIME, DATETIME, INTERVAL)
+11. **`spark/provider.go`** - Apache Spark SQL type provider
+    - Maps Spark types (incl. `array<T>` and `struct<...>`) to CEL types
+    - `LoadTableSchema` uses `DESCRIBE TABLE` (table name validated against an identifier regex)
+    - Accepts `*sql.DB` (caller owns connection); works with any database/sql driver such as gohive
+    - Skips trailing partition-info rows from `DESCRIBE TABLE` output
+
+12. **`sqltypes/types.go`** - Custom SQL type definitions for CEL (DATE, TIME, DATETIME, INTERVAL)
 
 ### Type System Integration
 
@@ -220,7 +226,7 @@ These validations prevent PostgreSQL syntax errors and ensure predictable behavi
 
 ### Testing Guidelines
 - Use the dialect-specific schema/provider for each dialect's tests
-- Use `pg.NewTypeProvider()` for PostgreSQL, `mysql.NewTypeProvider()` for MySQL, etc.
+- Use `pg.NewTypeProvider()` for PostgreSQL, `mysql.NewTypeProvider()` for MySQL, `spark.NewTypeProvider()` for Spark, etc.
 - Include tests for nested types, arrays, and JSON fields
 - Verify SQL output matches the target dialect's syntax
 - Use testcontainers for integration tests (PostgreSQL, MySQL, BigQuery)
@@ -380,6 +386,13 @@ schema := mysql.NewSchema([]mysql.FieldSchema{
 provider := mysql.NewTypeProvider(map[string]mysql.Schema{"TableName": schema})
 
 // SQLite, DuckDB, BigQuery follow the same pattern with their own type names
+
+// Spark SQL (struct/array/map nesting via type names)
+schema := spark.NewSchema([]spark.FieldSchema{
+    {Name: "id", Type: "bigint"},
+    {Name: "tags", Type: "string", Repeated: true, ElementType: "string"},
+})
+provider := spark.NewTypeProvider(map[string]spark.Schema{"TableName": schema})
 ```
 
 ### Dynamic Schema Loading
@@ -414,13 +427,19 @@ err = provider.LoadTableSchema(ctx, "tableName")
 client, _ := bigquery.NewClient(ctx, "project-id")
 provider, err := bqprovider.NewTypeProviderWithClient(ctx, client, "dataset_id")
 err = provider.LoadTableSchema(ctx, "tableName")
+
+// Spark SQL — accepts *sql.DB, uses DESCRIBE TABLE (validates table name)
+// Works with any database/sql driver, e.g. github.com/beltran/gohive for Hive/Spark Thrift.
+db, _ := sql.Open("hive", "user@host:10000/default")
+provider, err := spark.NewTypeProviderWithConnection(ctx, db)
+err = provider.LoadTableSchema(ctx, "catalog.schema.tablename")
 ```
 
 **Key differences per dialect:**
 - **PostgreSQL**: `NewTypeProviderWithConnection(ctx, connString)` — owns its pgxpool, `Close()` releases it
-- **MySQL/SQLite/DuckDB**: `NewTypeProviderWithConnection(ctx, *sql.DB)` — caller owns DB, `Close()` is no-op
+- **MySQL/SQLite/DuckDB/Spark**: `NewTypeProviderWithConnection(ctx, *sql.DB)` — caller owns DB, `Close()` is no-op
 - **BigQuery**: `NewTypeProviderWithClient(ctx, *bigquery.Client, datasetID)` — caller owns client, `Close()` is no-op
-- **SQLite**: Table name validated via regex (`^[a-zA-Z_][a-zA-Z0-9_]*$`) since PRAGMA doesn't support parameterized queries
+- **SQLite/Spark**: Table name validated via regex (Spark allows dots for `catalog.schema.table`) since `PRAGMA`/`DESCRIBE TABLE` don't accept parameterized queries
 
 ### CEL Environment Setup
 ```go
@@ -911,14 +930,17 @@ cel2sql/
 │   └── provider.go         # LoadTableSchema via information_schema + *sql.DB
 ├── bigquery/               # BigQuery type provider
 │   └── provider.go         # LoadTableSchema via BigQuery client API
+├── spark/                  # Apache Spark SQL type provider
+│   └── provider.go         # LoadTableSchema via DESCRIBE TABLE + *sql.DB
 ├── dialect/                # Dialect interface and implementations
-│   ├── dialect.go          # Core Dialect interface (~40 methods)
+│   ├── dialect.go          # Core Dialect interface (~47 methods)
 │   ├── index_advisor.go    # IndexAdvisor interface, PatternType, IndexPattern
 │   ├── postgres/           # PostgreSQL dialect + IndexAdvisor (BTREE, GIN, GIN+trgm)
 │   ├── mysql/              # MySQL dialect + IndexAdvisor (BTREE, FULLTEXT)
 │   ├── sqlite/             # SQLite dialect + IndexAdvisor (BTREE only)
 │   ├── duckdb/             # DuckDB dialect + IndexAdvisor (ART)
-│   └── bigquery/           # BigQuery dialect + IndexAdvisor (CLUSTERING, SEARCH_INDEX)
+│   ├── bigquery/           # BigQuery dialect + IndexAdvisor (CLUSTERING, SEARCH_INDEX)
+│   └── spark/              # Spark SQL dialect (no IndexAdvisor in v1)
 ├── sqltypes/               # Custom SQL types for CEL
 │   └── types.go
 ├── testcases/              # Shared test cases with per-dialect expected SQL

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # cel2sql
 
-> Convert [CEL (Common Expression Language)](https://cel.dev/) expressions to SQL for PostgreSQL, MySQL, SQLite, DuckDB, and BigQuery
+> Convert [CEL (Common Expression Language)](https://cel.dev/) expressions to SQL for PostgreSQL, MySQL, SQLite, DuckDB, BigQuery, and Apache Spark SQL
 
-[![Go Version](https://img.shields.io/badge/Go-1.24%2B-blue)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/Go-1.25%2B-blue)](https://golang.org)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17-336791)](https://www.postgresql.org)
 [![MySQL](https://img.shields.io/badge/MySQL-8.0-4479A1)](https://www.mysql.com)
 [![SQLite](https://img.shields.io/badge/SQLite-3-003B57)](https://www.sqlite.org)
 [![DuckDB](https://img.shields.io/badge/DuckDB-1.x-FFF000)](https://duckdb.org)
 [![BigQuery](https://img.shields.io/badge/BigQuery-GCP-4285F4)](https://cloud.google.com/bigquery)
+[![Spark](https://img.shields.io/badge/Spark-3.x-E25A1C)](https://spark.apache.org)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Benchmarks](https://img.shields.io/badge/benchmarks-performance%20tracking-green)](https://spandigital.github.io/cel2sql/dev/bench/)
 
@@ -65,7 +66,7 @@ func main() {
 
 ## Why cel2sql?
 
-✅ **Multi-Dialect**: PostgreSQL, MySQL, SQLite, DuckDB, and BigQuery from a single API
+✅ **Multi-Dialect**: PostgreSQL, MySQL, SQLite, DuckDB, BigQuery, and Apache Spark SQL from a single API
 ✅ **Type-Safe**: Catch errors at compile time, not runtime
 ✅ **Rich Features**: JSON/JSONB, arrays, regex, timestamps, and more
 ✅ **Well-Tested**: 100+ tests including integration tests with real databases
@@ -133,7 +134,7 @@ sql, err := cel2sql.Convert(ast,
 
 ## Multi-Dialect Support
 
-cel2sql supports 5 SQL dialects. PostgreSQL is the default; select other dialects with `WithDialect()`:
+cel2sql supports 6 SQL dialects. PostgreSQL is the default; select other dialects with `WithDialect()`:
 
 ```go
 import (
@@ -142,6 +143,7 @@ import (
     "github.com/spandigital/cel2sql/v3/dialect/sqlite"
     "github.com/spandigital/cel2sql/v3/dialect/duckdb"
     "github.com/spandigital/cel2sql/v3/dialect/bigquery"
+    "github.com/spandigital/cel2sql/v3/dialect/spark"
 )
 
 // PostgreSQL (default - no option needed)
@@ -158,21 +160,25 @@ sql, err := cel2sql.Convert(ast, cel2sql.WithDialect(duckdb.New()))
 
 // BigQuery
 sql, err := cel2sql.Convert(ast, cel2sql.WithDialect(bigquery.New()))
+
+// Apache Spark SQL
+sql, err := cel2sql.Convert(ast, cel2sql.WithDialect(spark.New()))
 ```
 
 ### Dialect Comparison
 
-| Feature | PostgreSQL | MySQL | SQLite | DuckDB | BigQuery |
-|---------|-----------|-------|--------|--------|----------|
-| String concat | `\|\|` | `CONCAT()` | `\|\|` | `\|\|` | `\|\|` |
-| Regex | `~ / ~*` | `REGEXP` | unsupported | `~ / ~*` | `REGEXP_CONTAINS()` |
-| JSON access | `->>'f'` | `->>'$.f'` | `json_extract()` | `->>'f'` | `JSON_VALUE()` |
-| Arrays | `ARRAY[...]` | JSON arrays | JSON arrays | `[...]` | `[...]` |
-| UNNEST | `UNNEST(x)` | `JSON_TABLE(...)` | `json_each(x)` | `UNNEST(x)` | `UNNEST(x)` |
-| Param placeholder | `$1, $2` | `?, ?` | `?, ?` | `$1, $2` | `@p1, @p2` |
-| Timestamp cast | `TIMESTAMP WITH TIME ZONE` | `DATETIME` | `datetime()` | `TIMESTAMPTZ` | `TIMESTAMP` |
-| Contains | `POSITION()` | `LOCATE()` | `INSTR()` | `CONTAINS()` | `STRPOS()` |
-| Index analysis | BTREE, GIN, GIN+trgm | BTREE, FULLTEXT | BTREE | ART | CLUSTERING, SEARCH_INDEX |
+| Feature | PostgreSQL | MySQL | SQLite | DuckDB | BigQuery | Spark |
+|---------|-----------|-------|--------|--------|----------|-------|
+| String concat | `\|\|` | `CONCAT()` | `\|\|` | `\|\|` | `\|\|` | `concat()` |
+| Regex | `~ / ~*` | `REGEXP` | unsupported | `~ / ~*` | `REGEXP_CONTAINS()` | `RLIKE` |
+| JSON access | `->>'f'` | `->>'$.f'` | `json_extract()` | `->>'f'` | `JSON_VALUE()` | `get_json_object()` |
+| Arrays | `ARRAY[...]` | JSON arrays | JSON arrays | `[...]` | `[...]` | `array(...)` |
+| Array index | 1-indexed | n/a | n/a | 1-indexed | 0-indexed (`OFFSET`) | 0-indexed |
+| UNNEST | `UNNEST(x)` | `JSON_TABLE(...)` | `json_each(x)` | `UNNEST(x)` | `UNNEST(x)` | `EXPLODE(x)` |
+| Param placeholder | `$1, $2` | `?, ?` | `?, ?` | `$1, $2` | `@p1, @p2` | `?, ?` |
+| Timestamp cast | `TIMESTAMP WITH TIME ZONE` | `DATETIME` | `datetime()` | `TIMESTAMPTZ` | `TIMESTAMP` | `TIMESTAMP` |
+| Contains | `POSITION()` | `LOCATE()` | `INSTR()` | `CONTAINS()` | `STRPOS()` | `LOCATE()` |
+| Index analysis | BTREE, GIN, GIN+trgm | BTREE, FULLTEXT | BTREE | ART | CLUSTERING, SEARCH_INDEX | not supported in v1 |
 
 ### Per-Dialect Type Providers
 
@@ -184,6 +190,7 @@ import "github.com/spandigital/cel2sql/v3/mysql"     // MySQL (*sql.DB)
 import "github.com/spandigital/cel2sql/v3/sqlite"    // SQLite (*sql.DB)
 import "github.com/spandigital/cel2sql/v3/duckdb"    // DuckDB (*sql.DB)
 import "github.com/spandigital/cel2sql/v3/bigquery"  // BigQuery (*bigquery.Client)
+import "github.com/spandigital/cel2sql/v3/spark"     // Spark SQL (*sql.DB; uses DESCRIBE TABLE)
 ```
 
 ## Query Analysis and Index Recommendations
@@ -229,15 +236,15 @@ for _, rec := range recommendations {
 
 ### Per-Dialect Index Types
 
-| Pattern | PostgreSQL | MySQL | SQLite | DuckDB | BigQuery |
-|---------|-----------|-------|--------|--------|----------|
-| Comparison | BTREE | BTREE | BTREE | ART | CLUSTERING |
-| JSON access | GIN | BTREE (functional) | _(skip)_ | ART | SEARCH_INDEX |
-| Regex | GIN + pg_trgm | FULLTEXT | _(skip)_ | _(skip)_ | _(skip)_ |
-| Array membership | GIN | _(skip)_ | _(skip)_ | ART | _(skip)_ |
-| Comprehension | GIN | _(skip)_ | _(skip)_ | ART | _(skip)_ |
+| Pattern | PostgreSQL | MySQL | SQLite | DuckDB | BigQuery | Spark |
+|---------|-----------|-------|--------|--------|----------|-------|
+| Comparison | BTREE | BTREE | BTREE | ART | CLUSTERING | _(skip)_ |
+| JSON access | GIN | BTREE (functional) | _(skip)_ | ART | SEARCH_INDEX | _(skip)_ |
+| Regex | GIN + pg_trgm | FULLTEXT | _(skip)_ | _(skip)_ | _(skip)_ | _(skip)_ |
+| Array membership | GIN | _(skip)_ | _(skip)_ | ART | _(skip)_ | _(skip)_ |
+| Comprehension | GIN | _(skip)_ | _(skip)_ | ART | _(skip)_ | _(skip)_ |
 
-Unsupported patterns are silently skipped (no recommendation emitted).
+Spark indexing depends on the storage layer (Delta Z-order, Iceberg sort, plain Parquet) and is out of scope for v1; index analysis is disabled for the Spark dialect. Unsupported patterns in other dialects are silently skipped.
 
 ### Example
 

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -17,6 +17,7 @@ const (
 	SQLite     Name = "sqlite"
 	DuckDB     Name = "duckdb"
 	BigQuery   Name = "bigquery"
+	Spark      Name = "spark"
 )
 
 // ErrUnsupportedFeature indicates that the requested feature is not supported by this dialect.

--- a/dialect/spark/dialect.go
+++ b/dialect/spark/dialect.go
@@ -1,0 +1,532 @@
+// Package spark implements the Apache Spark SQL dialect for cel2sql.
+package spark
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spandigital/cel2sql/v3/dialect"
+)
+
+// Dialect implements dialect.Dialect for Apache Spark SQL.
+type Dialect struct{}
+
+// New creates a new Spark SQL dialect.
+func New() *Dialect {
+	return &Dialect{}
+}
+
+func init() {
+	dialect.Register(dialect.Spark, func() dialect.Dialect { return New() })
+}
+
+// Ensure Dialect implements dialect.Dialect at compile time.
+var _ dialect.Dialect = (*Dialect)(nil)
+
+// Name returns the dialect name.
+func (d *Dialect) Name() dialect.Name { return dialect.Spark }
+
+// --- Literals ---
+
+// WriteStringLiteral writes a Spark SQL string literal with ” escaping.
+func (d *Dialect) WriteStringLiteral(w *strings.Builder, value string) {
+	escaped := strings.ReplaceAll(value, "'", "''")
+	w.WriteString("'")
+	w.WriteString(escaped)
+	w.WriteString("'")
+}
+
+// WriteBytesLiteral writes a Spark SQL byte literal as X'HEX'.
+func (d *Dialect) WriteBytesLiteral(w *strings.Builder, value []byte) error {
+	w.WriteString("X'")
+	for _, b := range value {
+		fmt.Fprintf(w, "%02X", b)
+	}
+	w.WriteString("'")
+	return nil
+}
+
+// WriteParamPlaceholder writes a Spark SQL positional parameter (?).
+// The paramIndex argument is intentionally unused: Spark JDBC uses
+// positional ? placeholders, so the converter relies on parameter order.
+func (d *Dialect) WriteParamPlaceholder(w *strings.Builder, _ int) {
+	w.WriteString("?")
+}
+
+// --- Operators ---
+
+// WriteStringConcat writes Spark string concatenation using the concat() function.
+// concat() works in all Spark versions; the || operator was added in 3.0+.
+func (d *Dialect) WriteStringConcat(w *strings.Builder, writeLHS, writeRHS func() error) error {
+	w.WriteString("concat(")
+	if err := writeLHS(); err != nil {
+		return err
+	}
+	w.WriteString(", ")
+	if err := writeRHS(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteRegexMatch writes a Spark SQL regex match using RLIKE.
+// Spark regex uses Java pattern syntax; (?i) inline flag is supported,
+// so caseInsensitive is folded into the pattern by ConvertRegex.
+func (d *Dialect) WriteRegexMatch(w *strings.Builder, writeTarget func() error, pattern string, _ bool) error {
+	if err := writeTarget(); err != nil {
+		return err
+	}
+	w.WriteString(" RLIKE '")
+	escaped := strings.ReplaceAll(pattern, "'", "''")
+	w.WriteString(escaped)
+	w.WriteString("'")
+	return nil
+}
+
+// WriteLikeEscape writes the Spark SQL LIKE escape clause.
+func (d *Dialect) WriteLikeEscape(w *strings.Builder) {
+	w.WriteString(" ESCAPE '\\\\'")
+}
+
+// WriteArrayMembership writes a Spark array membership test using array_contains().
+func (d *Dialect) WriteArrayMembership(w *strings.Builder, writeElem, writeArray func() error) error {
+	w.WriteString("array_contains(")
+	if err := writeArray(); err != nil {
+		return err
+	}
+	w.WriteString(", ")
+	if err := writeElem(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// --- Type Casting ---
+
+// WriteCastToNumeric writes a Spark numeric cast suffix (postfix `::DOUBLE` style is
+// not supported; the converter wraps in CAST(... AS DOUBLE) instead via WriteTypeName).
+// This method is called only as a fallback for ad-hoc casts, so emit the standard suffix
+// pattern that Spark accepts in expressions like `(expr)::DOUBLE` is invalid; use CAST.
+func (d *Dialect) WriteCastToNumeric(w *strings.Builder) {
+	// Spark requires CAST(...). The converter typically writes "(" + expr + ")" before
+	// calling this; we close the parens and append a CAST wrapper using the AS clause.
+	// However, the existing converter pattern for other dialects appends ::TYPE after
+	// the parenthesized expression. To stay shape-compatible we emit a comment-safe
+	// CAST tail: ` AS DOUBLE)`. This expects the converter to have opened with `CAST(`.
+	// In practice cel2sql uses the postfix path via DuckDB/PostgreSQL semantics; for
+	// Spark we emit a no-op suffix and let CAST happen via WriteTypeName / explicit casts.
+	// Empty implementation keeps SQL valid: `(expr)` without a cast still evaluates.
+	// JSON-text comparison paths in the converter will explicitly use CAST.
+	_ = w
+}
+
+// WriteTypeName writes a Spark SQL type name for CAST expressions.
+func (d *Dialect) WriteTypeName(w *strings.Builder, celTypeName string) {
+	switch celTypeName {
+	case "bool":
+		w.WriteString("BOOLEAN")
+	case "bytes":
+		w.WriteString("BINARY")
+	case "double":
+		w.WriteString("DOUBLE")
+	case "int":
+		w.WriteString("BIGINT")
+	case "string":
+		w.WriteString("STRING")
+	case "uint":
+		w.WriteString("BIGINT")
+	default:
+		w.WriteString(strings.ToUpper(celTypeName))
+	}
+}
+
+// WriteEpochExtract writes UNIX_TIMESTAMP(expr) for Spark.
+func (d *Dialect) WriteEpochExtract(w *strings.Builder, writeExpr func() error) error {
+	w.WriteString("UNIX_TIMESTAMP(")
+	if err := writeExpr(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteTimestampCast writes a Spark CAST to TIMESTAMP.
+func (d *Dialect) WriteTimestampCast(w *strings.Builder, writeExpr func() error) error {
+	w.WriteString("CAST(")
+	if err := writeExpr(); err != nil {
+		return err
+	}
+	w.WriteString(" AS TIMESTAMP)")
+	return nil
+}
+
+// --- Arrays ---
+
+// WriteArrayLiteralOpen writes the Spark array literal opening (array().
+func (d *Dialect) WriteArrayLiteralOpen(w *strings.Builder) {
+	w.WriteString("array(")
+}
+
+// WriteArrayLiteralClose writes the Spark array literal closing.
+func (d *Dialect) WriteArrayLiteralClose(w *strings.Builder) {
+	w.WriteString(")")
+}
+
+// WriteArrayLength writes COALESCE(size(expr), 0) for Spark.
+// Spark's size() returns -1 for null; COALESCE+ifnull-style handling matches cel2sql semantics
+// where size(null) should be 0.
+func (d *Dialect) WriteArrayLength(w *strings.Builder, dimension int, writeExpr func() error) error {
+	if dimension > 1 {
+		return fmt.Errorf("%w: spark dialect does not support multi-dimensional arrays (dimension=%d)", dialect.ErrUnsupportedFeature, dimension)
+	}
+	w.WriteString("COALESCE(size(")
+	if err := writeExpr(); err != nil {
+		return err
+	}
+	w.WriteString("), 0)")
+	return nil
+}
+
+// WriteListIndex writes Spark 0-indexed array access.
+func (d *Dialect) WriteListIndex(w *strings.Builder, writeArray, writeIndex func() error) error {
+	if err := writeArray(); err != nil {
+		return err
+	}
+	w.WriteString("[")
+	if err := writeIndex(); err != nil {
+		return err
+	}
+	w.WriteString("]")
+	return nil
+}
+
+// WriteListIndexConst writes a Spark constant array index (0-indexed).
+func (d *Dialect) WriteListIndexConst(w *strings.Builder, writeArray func() error, index int64) error {
+	if err := writeArray(); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "[%d]", index)
+	return nil
+}
+
+// WriteEmptyTypedArray writes an empty Spark typed array.
+func (d *Dialect) WriteEmptyTypedArray(w *strings.Builder, typeName string) {
+	w.WriteString("CAST(array() AS ARRAY<")
+	w.WriteString(sparkTypeName(typeName))
+	w.WriteString(">)")
+}
+
+// --- JSON ---
+
+// WriteJSONFieldAccess writes Spark JSON field access using get_json_object.
+// Spark's get_json_object always returns a string; the same function is used
+// for both intermediate and final access (Spark has no JSON_QUERY equivalent).
+func (d *Dialect) WriteJSONFieldAccess(w *strings.Builder, writeBase func() error, fieldName string, _ bool) error {
+	w.WriteString("get_json_object(")
+	if err := writeBase(); err != nil {
+		return err
+	}
+	w.WriteString(", '$.")
+	w.WriteString(escapeJSONFieldName(fieldName))
+	w.WriteString("')")
+	return nil
+}
+
+// WriteJSONExistence writes a Spark JSON key existence check.
+func (d *Dialect) WriteJSONExistence(w *strings.Builder, _ bool, fieldName string, writeBase func() error) error {
+	w.WriteString("get_json_object(")
+	if err := writeBase(); err != nil {
+		return err
+	}
+	w.WriteString(", '$.")
+	w.WriteString(escapeJSONFieldName(fieldName))
+	w.WriteString("') IS NOT NULL")
+	return nil
+}
+
+// WriteJSONArrayElements writes Spark JSON array expansion using from_json + explode.
+// The converter wraps this in a subquery / lateral form upstream; we emit the
+// from_json result so callers can chain explode() externally.
+func (d *Dialect) WriteJSONArrayElements(w *strings.Builder, _, _ bool, writeExpr func() error) error {
+	w.WriteString("from_json(")
+	if err := writeExpr(); err != nil {
+		return err
+	}
+	w.WriteString(", 'ARRAY<STRING>')")
+	return nil
+}
+
+// WriteJSONArrayLength writes COALESCE(size(from_json(expr, 'ARRAY<STRING>')), 0) for Spark.
+func (d *Dialect) WriteJSONArrayLength(w *strings.Builder, writeExpr func() error) error {
+	w.WriteString("COALESCE(size(from_json(")
+	if err := writeExpr(); err != nil {
+		return err
+	}
+	w.WriteString(", 'ARRAY<STRING>')), 0)")
+	return nil
+}
+
+// WriteJSONExtractPath writes a Spark JSON path existence check using get_json_object.
+func (d *Dialect) WriteJSONExtractPath(w *strings.Builder, pathSegments []string, writeRoot func() error) error {
+	w.WriteString("get_json_object(")
+	if err := writeRoot(); err != nil {
+		return err
+	}
+	w.WriteString(", '$")
+	for _, segment := range pathSegments {
+		w.WriteString(".")
+		w.WriteString(escapeJSONFieldName(segment))
+	}
+	w.WriteString("') IS NOT NULL")
+	return nil
+}
+
+// WriteJSONArrayMembership writes Spark JSON array membership.
+func (d *Dialect) WriteJSONArrayMembership(w *strings.Builder, _ string, writeExpr func() error) error {
+	w.WriteString("from_json(")
+	if err := writeExpr(); err != nil {
+		return err
+	}
+	w.WriteString(", 'ARRAY<STRING>')")
+	return nil
+}
+
+// WriteNestedJSONArrayMembership writes Spark nested JSON array membership.
+func (d *Dialect) WriteNestedJSONArrayMembership(w *strings.Builder, writeExpr func() error) error {
+	w.WriteString("from_json(")
+	if err := writeExpr(); err != nil {
+		return err
+	}
+	w.WriteString(", 'ARRAY<STRING>')")
+	return nil
+}
+
+// --- Timestamps ---
+
+// WriteDuration writes a Spark INTERVAL literal.
+func (d *Dialect) WriteDuration(w *strings.Builder, value int64, unit string) {
+	fmt.Fprintf(w, "INTERVAL %d %s", value, unit)
+}
+
+// WriteInterval writes a Spark INTERVAL expression.
+func (d *Dialect) WriteInterval(w *strings.Builder, writeValue func() error, unit string) error {
+	w.WriteString("INTERVAL ")
+	if err := writeValue(); err != nil {
+		return err
+	}
+	w.WriteString(" ")
+	w.WriteString(unit)
+	return nil
+}
+
+// WriteExtract writes a Spark EXTRACT expression.
+// Spark dayofweek() returns 1=Sunday..7=Saturday; CEL convention is 0=Sunday..6=Saturday.
+func (d *Dialect) WriteExtract(w *strings.Builder, part string, writeExpr func() error, writeTZ func() error) error {
+	isDOW := part == "DOW"
+	if isDOW {
+		w.WriteString("(dayofweek(")
+		if err := writeExpr(); err != nil {
+			return err
+		}
+		if writeTZ != nil {
+			w.WriteString(" AT TIME ZONE ")
+			if err := writeTZ(); err != nil {
+				return err
+			}
+		}
+		w.WriteString(") - 1)")
+		return nil
+	}
+	w.WriteString("EXTRACT(")
+	w.WriteString(part)
+	w.WriteString(" FROM ")
+	if err := writeExpr(); err != nil {
+		return err
+	}
+	if writeTZ != nil {
+		w.WriteString(" AT TIME ZONE ")
+		if err := writeTZ(); err != nil {
+			return err
+		}
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteTimestampArithmetic writes Spark timestamp arithmetic.
+func (d *Dialect) WriteTimestampArithmetic(w *strings.Builder, op string, writeTS, writeDur func() error) error {
+	if err := writeTS(); err != nil {
+		return err
+	}
+	w.WriteString(" ")
+	w.WriteString(op)
+	w.WriteString(" ")
+	return writeDur()
+}
+
+// --- String Functions ---
+
+// WriteContains writes Spark string contains using LOCATE() > 0.
+// LOCATE(substr, str) returns 1-based position or 0 when not found.
+func (d *Dialect) WriteContains(w *strings.Builder, writeHaystack, writeNeedle func() error) error {
+	w.WriteString("LOCATE(")
+	if err := writeNeedle(); err != nil {
+		return err
+	}
+	w.WriteString(", ")
+	if err := writeHaystack(); err != nil {
+		return err
+	}
+	w.WriteString(") > 0")
+	return nil
+}
+
+// WriteSplit writes Spark string split using split().
+func (d *Dialect) WriteSplit(w *strings.Builder, writeStr, writeDelim func() error) error {
+	w.WriteString("split(")
+	if err := writeStr(); err != nil {
+		return err
+	}
+	w.WriteString(", ")
+	if err := writeDelim(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteSplitWithLimit writes Spark string split with limit (3-arg split, Spark 3.x+).
+func (d *Dialect) WriteSplitWithLimit(w *strings.Builder, writeStr, writeDelim func() error, limit int64) error {
+	w.WriteString("split(")
+	if err := writeStr(); err != nil {
+		return err
+	}
+	w.WriteString(", ")
+	if err := writeDelim(); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, ", %d)", limit)
+	return nil
+}
+
+// WriteJoin writes Spark array join using array_join().
+func (d *Dialect) WriteJoin(w *strings.Builder, writeArray, writeDelim func() error) error {
+	w.WriteString("array_join(")
+	if err := writeArray(); err != nil {
+		return err
+	}
+	w.WriteString(", ")
+	if err := writeDelim(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// --- Comprehensions ---
+
+// WriteUnnest writes Spark explode-style unnesting via lateral view replacement.
+// Note: cel2sql wraps this in an ARRAY-building subquery; Spark uses array
+// higher-order functions (transform/filter/exists/forall) which don't need UNNEST.
+// For the SELECT FROM UNNEST() pattern Spark requires a lateral view. We emit
+// EXPLODE() and rely on the converter's subquery scaffolding.
+func (d *Dialect) WriteUnnest(w *strings.Builder, writeSource func() error) error {
+	w.WriteString("EXPLODE(")
+	if err := writeSource(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteArraySubqueryOpen writes the Spark array-building subquery prefix.
+// Spark has no ARRAY(SELECT ...) constructor; collect_list() inside a subquery
+// is the closest equivalent.
+func (d *Dialect) WriteArraySubqueryOpen(w *strings.Builder) {
+	w.WriteString("(SELECT collect_list(")
+}
+
+// WriteArraySubqueryExprClose closes the collect_list() argument list.
+func (d *Dialect) WriteArraySubqueryExprClose(w *strings.Builder) {
+	w.WriteString(")")
+}
+
+// --- Struct ---
+
+// WriteStructOpen writes the Spark struct literal opening using struct().
+func (d *Dialect) WriteStructOpen(w *strings.Builder) {
+	w.WriteString("struct(")
+}
+
+// WriteStructClose writes the Spark struct literal closing.
+func (d *Dialect) WriteStructClose(w *strings.Builder) {
+	w.WriteString(")")
+}
+
+// --- Validation ---
+
+// MaxIdentifierLength returns 128 for Spark (Hive-derived limit).
+func (d *Dialect) MaxIdentifierLength() int {
+	return 128
+}
+
+// ValidateFieldName validates a field name against Spark naming rules.
+func (d *Dialect) ValidateFieldName(name string) error {
+	return validateFieldName(name)
+}
+
+// ReservedKeywords returns the set of reserved SQL keywords for Spark.
+func (d *Dialect) ReservedKeywords() map[string]bool {
+	return reservedSQLKeywords
+}
+
+// --- Regex ---
+
+// ConvertRegex converts an RE2 regex pattern to Spark/Java regex format.
+// Spark uses java.util.regex.Pattern, which is largely a superset of RE2 for
+// the safe patterns cel2sql accepts.
+func (d *Dialect) ConvertRegex(re2Pattern string) (string, bool, error) {
+	return convertRE2ToSpark(re2Pattern)
+}
+
+// SupportsRegex returns true as Spark supports regex via RLIKE.
+func (d *Dialect) SupportsRegex() bool { return true }
+
+// --- Capabilities ---
+
+// SupportsNativeArrays returns true as Spark has native ARRAY<T> types.
+func (d *Dialect) SupportsNativeArrays() bool { return true }
+
+// SupportsJSONB returns false as Spark has no separate JSONB type.
+func (d *Dialect) SupportsJSONB() bool { return false }
+
+// SupportsIndexAnalysis returns false. Spark indexing is highly storage-layer-specific
+// (Delta Z-order vs Iceberg sort vs plain Parquet) and out of scope for v1.
+func (d *Dialect) SupportsIndexAnalysis() bool { return false }
+
+// --- Internal helpers ---
+
+// escapeJSONFieldName escapes single quotes in JSON field names for Spark.
+func escapeJSONFieldName(fieldName string) string {
+	return strings.ReplaceAll(fieldName, "'", "''")
+}
+
+// sparkTypeName converts a CEL/common type name to a Spark type name.
+func sparkTypeName(typeName string) string {
+	switch strings.ToLower(typeName) {
+	case "text", "string", "varchar", "char":
+		return "STRING"
+	case "int", "integer", "bigint", "int64", "long":
+		return "BIGINT"
+	case "double", "float", "real", "float64":
+		return "DOUBLE"
+	case "boolean", "bool":
+		return "BOOLEAN"
+	case "bytes", "bytea", "blob", "binary":
+		return "BINARY"
+	default:
+		return strings.ToUpper(typeName)
+	}
+}

--- a/dialect/spark/dialect.go
+++ b/dialect/spark/dialect.go
@@ -105,21 +105,13 @@ func (d *Dialect) WriteArrayMembership(w *strings.Builder, writeElem, writeArray
 
 // --- Type Casting ---
 
-// WriteCastToNumeric writes a Spark numeric cast suffix (postfix `::DOUBLE` style is
-// not supported; the converter wraps in CAST(... AS DOUBLE) instead via WriteTypeName).
-// This method is called only as a fallback for ad-hoc casts, so emit the standard suffix
-// pattern that Spark accepts in expressions like `(expr)::DOUBLE` is invalid; use CAST.
+// WriteCastToNumeric writes a Spark numeric coercion suffix.
+// Spark does not support PostgreSQL-style `::TYPE` postfix casts, so we use the
+// arithmetic coercion `+ 0` (same convention MySQL and SQLite use): `'5' + 0`
+// evaluates as a number in Spark, ensuring JSON text extractions are compared
+// numerically rather than lexicographically.
 func (d *Dialect) WriteCastToNumeric(w *strings.Builder) {
-	// Spark requires CAST(...). The converter typically writes "(" + expr + ")" before
-	// calling this; we close the parens and append a CAST wrapper using the AS clause.
-	// However, the existing converter pattern for other dialects appends ::TYPE after
-	// the parenthesized expression. To stay shape-compatible we emit a comment-safe
-	// CAST tail: ` AS DOUBLE)`. This expects the converter to have opened with `CAST(`.
-	// In practice cel2sql uses the postfix path via DuckDB/PostgreSQL semantics; for
-	// Spark we emit a no-op suffix and let CAST happen via WriteTypeName / explicit casts.
-	// Empty implementation keeps SQL valid: `(expr)` without a cast still evaluates.
-	// JSON-text comparison paths in the converter will explicitly use CAST.
-	_ = w
+	w.WriteString(" + 0")
 }
 
 // WriteTypeName writes a Spark SQL type name for CAST expressions.
@@ -246,15 +238,17 @@ func (d *Dialect) WriteJSONExistence(w *strings.Builder, _ bool, fieldName strin
 	return nil
 }
 
-// WriteJSONArrayElements writes Spark JSON array expansion using from_json + explode.
-// The converter wraps this in a subquery / lateral form upstream; we emit the
-// from_json result so callers can chain explode() externally.
+// WriteJSONArrayElements writes Spark JSON array expansion as EXPLODE(from_json(...)).
+// The converter uses this in `FROM <here> AS iter`, so the result must be a
+// set-returning expression. EXPLODE turns the parsed array into a relation of
+// element rows. Element type is fixed to STRING in v1; comparisons coerce via
+// arithmetic context (see WriteCastToNumeric).
 func (d *Dialect) WriteJSONArrayElements(w *strings.Builder, _, _ bool, writeExpr func() error) error {
-	w.WriteString("from_json(")
+	w.WriteString("EXPLODE(from_json(")
 	if err := writeExpr(); err != nil {
 		return err
 	}
-	w.WriteString(", 'ARRAY<STRING>')")
+	w.WriteString(", 'ARRAY<STRING>'))")
 	return nil
 }
 
@@ -283,23 +277,28 @@ func (d *Dialect) WriteJSONExtractPath(w *strings.Builder, pathSegments []string
 	return nil
 }
 
-// WriteJSONArrayMembership writes Spark JSON array membership.
+// WriteJSONArrayMembership writes Spark JSON array membership as a scalar
+// subquery that scans elements. The converter writes `lhs = ` before this,
+// so the result is `lhs = (SELECT col FROM (SELECT EXPLODE(from_json(rhs,
+// 'ARRAY<STRING>')) AS col) t)`. This mirrors SQLite's `lhs = (SELECT value
+// FROM json_each(...))` pattern; both dialects rely on the subquery
+// returning at most one match for the comparison to succeed.
 func (d *Dialect) WriteJSONArrayMembership(w *strings.Builder, _ string, writeExpr func() error) error {
-	w.WriteString("from_json(")
+	w.WriteString("(SELECT col FROM (SELECT EXPLODE(from_json(")
 	if err := writeExpr(); err != nil {
 		return err
 	}
-	w.WriteString(", 'ARRAY<STRING>')")
+	w.WriteString(", 'ARRAY<STRING>')) AS col) t)")
 	return nil
 }
 
 // WriteNestedJSONArrayMembership writes Spark nested JSON array membership.
 func (d *Dialect) WriteNestedJSONArrayMembership(w *strings.Builder, writeExpr func() error) error {
-	w.WriteString("from_json(")
+	w.WriteString("(SELECT col FROM (SELECT EXPLODE(from_json(")
 	if err := writeExpr(); err != nil {
 		return err
 	}
-	w.WriteString(", 'ARRAY<STRING>')")
+	w.WriteString(", 'ARRAY<STRING>')) AS col) t)")
 	return nil
 }
 

--- a/dialect/spark/regex.go
+++ b/dialect/spark/regex.go
@@ -1,0 +1,127 @@
+package spark
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Regex pattern complexity limits to prevent ReDoS attacks (CWE-1333).
+const (
+	maxRegexPatternLength = 500
+	maxRegexGroups        = 20
+	maxRegexNestingDepth  = 10
+)
+
+// convertRE2ToSpark converts an RE2 regex pattern to Spark/Java regex format.
+// Spark uses java.util.regex.Pattern, which is a superset of RE2 for the safe
+// subset cel2sql accepts (we reject lookahead/lookbehind, named captures, and
+// non-(?i) inline flags). Java natively supports \d, \w, \s, \b, (?:...), and
+// inline (?i), so most patterns pass through unchanged.
+func convertRE2ToSpark(re2Pattern string) (string, bool, error) {
+	// 1. Pattern length validation.
+	if len(re2Pattern) > maxRegexPatternLength {
+		return "", false, fmt.Errorf("pattern length %d exceeds limit of %d characters", len(re2Pattern), maxRegexPatternLength)
+	}
+
+	// 2. Validate the pattern compiles under RE2 (cel2sql input contract).
+	if _, err := regexp.Compile(re2Pattern); err != nil {
+		return "", false, fmt.Errorf("invalid regex pattern: %w", err)
+	}
+
+	// 3. Reject features RE2 forbids but users sometimes ask for.
+	if strings.Contains(re2Pattern, "(?=") || strings.Contains(re2Pattern, "(?!") {
+		return "", false, errors.New("lookahead assertions (?=...), (?!...) are not supported")
+	}
+	if strings.Contains(re2Pattern, "(?<=") || strings.Contains(re2Pattern, "(?<!") {
+		return "", false, errors.New("lookbehind assertions (?<=...), (?<!...) are not supported")
+	}
+	if strings.Contains(re2Pattern, "(?P<") {
+		return "", false, errors.New("named capture groups (?P<name>...) are not supported")
+	}
+
+	// 4. Detect catastrophic nested quantifiers.
+	if matched, _ := regexp.MatchString(`[*+][*+]`, re2Pattern); matched {
+		return "", false, errors.New("regex contains catastrophic nested quantifiers that could cause ReDoS")
+	}
+
+	// 5. Check for nested quantifiers in groups.
+	depth := 0
+	groupHasQuantifier := make([]bool, 0)
+	for i := 0; i < len(re2Pattern); i++ {
+		char := re2Pattern[i]
+		if i > 0 && re2Pattern[i-1] == '\\' {
+			continue
+		}
+		switch char {
+		case '(':
+			depth++
+			groupHasQuantifier = append(groupHasQuantifier, false)
+		case ')':
+			if depth > 0 {
+				depth--
+				if i+1 < len(re2Pattern) {
+					nextChar := re2Pattern[i+1]
+					if nextChar == '*' || nextChar == '+' || nextChar == '?' || nextChar == '{' {
+						if len(groupHasQuantifier) > 0 && groupHasQuantifier[len(groupHasQuantifier)-1] {
+							return "", false, errors.New("regex contains catastrophic nested quantifiers that could cause ReDoS")
+						}
+					}
+				}
+				if len(groupHasQuantifier) > 0 {
+					groupHasQuantifier = groupHasQuantifier[:len(groupHasQuantifier)-1]
+				}
+			}
+		case '*', '+', '?', '{':
+			for j := range groupHasQuantifier {
+				groupHasQuantifier[j] = true
+			}
+		}
+	}
+
+	// 6. Check group count limit.
+	groupCount := strings.Count(re2Pattern, "(") - strings.Count(re2Pattern, "\\(")
+	if groupCount > maxRegexGroups {
+		return "", false, fmt.Errorf("regex contains %d capture groups, exceeds limit of %d", groupCount, maxRegexGroups)
+	}
+
+	// 7. Check for quantified alternation.
+	quantifiedAlternation := regexp.MustCompile(`\([^)]*\|[^)]*\)[*+]`)
+	if quantifiedAlternation.MatchString(re2Pattern) {
+		return "", false, errors.New("regex contains quantified alternation that could cause ReDoS")
+	}
+
+	// 8. Check nesting depth.
+	maxDepthVal := 0
+	currentDepth := 0
+	for i := 0; i < len(re2Pattern); i++ {
+		if i > 0 && re2Pattern[i-1] == '\\' {
+			continue
+		}
+		switch re2Pattern[i] {
+		case '(':
+			currentDepth++
+			if currentDepth > maxDepthVal {
+				maxDepthVal = currentDepth
+			}
+		case ')':
+			if currentDepth > 0 {
+				currentDepth--
+			}
+		}
+	}
+	if maxDepthVal > maxRegexNestingDepth {
+		return "", false, fmt.Errorf("nesting depth %d exceeds limit of %d", maxDepthVal, maxRegexNestingDepth)
+	}
+
+	// 9. Reject inline flags other than (?i) anywhere in the pattern.
+	if strings.Contains(re2Pattern, "(?m") || strings.Contains(re2Pattern, "(?s") || strings.Contains(re2Pattern, "(?-") {
+		return "", false, errors.New("inline flags other than (?i) are not supported in Spark regex")
+	}
+
+	// Java/Spark regex supports (?i) inline, \d/\w/\s, \b, and (?:...) natively.
+	// Pass the pattern through unchanged; the inline (?i) is honoured by Spark's
+	// regex engine, so we report caseInsensitive=false here.
+	return re2Pattern, false, nil
+}

--- a/dialect/spark/validation.go
+++ b/dialect/spark/validation.go
@@ -1,0 +1,63 @@
+package spark
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	// fieldNameRegexp validates Spark identifier format (letter/underscore start,
+	// alphanumerics + underscore body). Spark also accepts backtick-quoted
+	// identifiers but we restrict to the unquoted form for safety.
+	fieldNameRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+	// reservedSQLKeywords contains Spark SQL reserved keywords.
+	// Source: Apache Spark docs (sql-ref-ansi-compliance.html#sql-keywords)
+	// plus the standard SQL set already covered by other dialects. Lowercased.
+	reservedSQLKeywords = map[string]bool{
+		"all": true, "alter": true, "and": true, "anti": true, "any": true,
+		"array": true, "as": true, "asc": true, "between": true, "both": true,
+		"by": true, "case": true, "cast": true, "check": true, "cluster": true,
+		"collate": true, "column": true, "create": true, "cross": true,
+		"cube": true, "current": true, "current_date": true, "current_time": true,
+		"current_timestamp": true, "current_user": true, "default": true,
+		"delete": true, "desc": true, "describe": true, "distinct": true,
+		"drop": true, "else": true, "end": true, "escape": true, "except": true,
+		"exists": true, "false": true, "fetch": true, "filter": true,
+		"for": true, "foreign": true, "from": true, "full": true, "function": true,
+		"grant": true, "group": true, "grouping": true, "having": true,
+		"hour": true, "in": true, "inner": true, "insert": true, "intersect": true,
+		"interval": true, "into": true, "is": true, "join": true, "lateral": true,
+		"leading": true, "left": true, "like": true, "limit": true, "local": true,
+		"map": true, "minute": true, "month": true, "natural": true, "no": true,
+		"not": true, "null": true, "of": true, "on": true, "only": true,
+		"or": true, "order": true, "outer": true, "overlaps": true, "primary": true,
+		"references": true, "right": true, "rollup": true, "row": true,
+		"rows": true, "second": true, "select": true, "semi": true,
+		"session_user": true, "set": true, "some": true, "struct": true,
+		"table": true, "tablesample": true, "then": true, "time": true,
+		"to": true, "trailing": true, "true": true, "union": true, "unique": true,
+		"unknown": true, "update": true, "user": true, "using": true,
+		"values": true, "when": true, "where": true, "window": true, "with": true,
+		"year": true,
+	}
+)
+
+// validateFieldName validates that a field name follows Spark naming conventions.
+func validateFieldName(name string) error {
+	if len(name) == 0 {
+		return errors.New("field name cannot be empty")
+	}
+
+	if !fieldNameRegexp.MatchString(name) {
+		return fmt.Errorf("field name %q must start with a letter or underscore and contain only alphanumeric characters and underscores", name)
+	}
+
+	if reservedSQLKeywords[strings.ToLower(name)] {
+		return fmt.Errorf("field name %q is a reserved SQL keyword and cannot be used without quoting", name)
+	}
+
+	return nil
+}

--- a/spark/export_test.go
+++ b/spark/export_test.go
@@ -1,0 +1,5 @@
+package spark
+
+// SparkColumnToFieldSchemaForTest is a test-only export of sparkColumnToFieldSchema.
+// Defined in an _test.go file so it's only compiled into tests.
+var SparkColumnToFieldSchemaForTest = sparkColumnToFieldSchema

--- a/spark/provider.go
+++ b/spark/provider.go
@@ -1,0 +1,334 @@
+// Package spark provides a Spark SQL type provider for CEL type system integration.
+package spark
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+
+	"github.com/spandigital/cel2sql/v3/schema"
+	"github.com/spandigital/cel2sql/v3/sqltypes"
+)
+
+// Sentinel errors for the spark package.
+var (
+	// ErrInvalidSchema indicates a problem with the provided schema or database introspection.
+	ErrInvalidSchema = errors.New("invalid schema")
+)
+
+// FieldSchema is an alias for schema.FieldSchema.
+type FieldSchema = schema.FieldSchema
+
+// Schema is an alias for schema.Schema.
+type Schema = schema.Schema
+
+// NewSchema creates a new Schema. This is an alias for schema.NewSchema.
+var NewSchema = schema.NewSchema
+
+// validTableName matches Spark identifier rules. The Spark catalog APIs
+// (DESCRIBE TABLE) do not accept positional parameters, so we validate the
+// table name string before interpolating it into the query.
+var validTableName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_.]*$`)
+
+// TypeProvider is the Spark SQL type provider interface.
+type TypeProvider interface {
+	types.Provider
+	LoadTableSchema(ctx context.Context, tableName string) error
+	GetSchemas() map[string]Schema
+	Close()
+}
+
+type typeProvider struct {
+	schemas map[string]Schema
+	db      *sql.DB
+}
+
+// NewTypeProvider creates a new Spark SQL type provider with pre-defined schemas.
+func NewTypeProvider(schemas map[string]Schema) TypeProvider {
+	return &typeProvider{schemas: schemas}
+}
+
+// NewTypeProviderWithConnection creates a new Spark SQL type provider that can
+// introspect schemas via DESCRIBE TABLE. The caller owns the *sql.DB and is
+// responsible for closing it. Works with any database/sql driver (e.g. gohive
+// for Hive/SparkThrift, or a JDBC bridge).
+func NewTypeProviderWithConnection(_ context.Context, db *sql.DB) (TypeProvider, error) {
+	if db == nil {
+		return nil, fmt.Errorf("%w: db connection must not be nil", ErrInvalidSchema)
+	}
+	return &typeProvider{
+		schemas: make(map[string]Schema),
+		db:      db,
+	}, nil
+}
+
+// LoadTableSchema loads schema information for a table from the Spark catalog
+// using DESCRIBE TABLE. The table name must be a valid Spark identifier (letters,
+// digits, underscore, dot for catalog.schema.table); this is enforced because
+// DESCRIBE TABLE does not accept parameterized queries.
+func (tp *typeProvider) LoadTableSchema(ctx context.Context, tableName string) error {
+	if !validTableName.MatchString(tableName) {
+		return fmt.Errorf("%w: invalid table name %q", ErrInvalidSchema, tableName)
+	}
+	if tp.db == nil {
+		return fmt.Errorf("%w: no database connection available", ErrInvalidSchema)
+	}
+
+	query := "DESCRIBE TABLE " + tableName
+	rows, err := tp.db.QueryContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("%w: failed to describe table", ErrInvalidSchema)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var fields []FieldSchema
+	for rows.Next() {
+		var colName, dataType, comment sql.NullString
+		if err := rows.Scan(&colName, &dataType, &comment); err != nil {
+			return fmt.Errorf("%w: failed to scan row", ErrInvalidSchema)
+		}
+		// DESCRIBE TABLE in Spark emits trailing partition info rows whose col_name
+		// starts with "#" or is empty; skip them.
+		name := strings.TrimSpace(colName.String)
+		if name == "" || strings.HasPrefix(name, "#") {
+			continue
+		}
+		fields = append(fields, sparkColumnToFieldSchema(name, dataType.String))
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("%w: error iterating rows", ErrInvalidSchema)
+	}
+	if len(fields) == 0 {
+		return fmt.Errorf("%w: table %q has no columns or does not exist", ErrInvalidSchema, tableName)
+	}
+
+	tp.schemas[tableName] = NewSchema(fields)
+	return nil
+}
+
+// sparkColumnToFieldSchema converts a Spark DESCRIBE TABLE row into a FieldSchema,
+// detecting array<T>, struct<...>, and primitive types.
+func sparkColumnToFieldSchema(name, dataType string) FieldSchema {
+	dt := strings.TrimSpace(strings.ToLower(dataType))
+
+	if isArr, elem := detectSparkArray(dt); isArr {
+		return FieldSchema{
+			Name:        name,
+			Type:        normalizeSparkType(elem),
+			Repeated:    true,
+			Dimensions:  1,
+			ElementType: normalizeSparkType(elem),
+		}
+	}
+	if strings.HasPrefix(dt, "struct<") {
+		nested, ok := parseSparkStruct(dt)
+		if ok {
+			return FieldSchema{
+				Name:   name,
+				Type:   "struct",
+				Schema: nested,
+			}
+		}
+	}
+	return FieldSchema{
+		Name: name,
+		Type: normalizeSparkType(dt),
+	}
+}
+
+// detectSparkArray reports whether a Spark type string is array<T> and returns
+// the element type T. Nested arrays (array<array<T>>) collapse to dimension 1
+// in v1; multi-dimensional arrays are uncommon in Spark and unsupported by
+// the dialect emitter.
+func detectSparkArray(dt string) (isArray bool, elementType string) {
+	if !strings.HasPrefix(dt, "array<") || !strings.HasSuffix(dt, ">") {
+		return false, ""
+	}
+	return true, dt[len("array<") : len(dt)-1]
+}
+
+// parseSparkStruct parses a Spark struct type string of the form
+// `struct<field1:type1,field2:type2>` into nested FieldSchemas. Returns
+// false if the input cannot be parsed (e.g., malformed nesting); callers
+// should fall back to treating the field as opaque.
+func parseSparkStruct(dt string) ([]FieldSchema, bool) {
+	if !strings.HasPrefix(dt, "struct<") || !strings.HasSuffix(dt, ">") {
+		return nil, false
+	}
+	body := dt[len("struct<") : len(dt)-1]
+	if body == "" {
+		return nil, true
+	}
+	parts := splitTopLevel(body, ',')
+	out := make([]FieldSchema, 0, len(parts))
+	for _, p := range parts {
+		colon := indexTopLevel(p, ':')
+		if colon < 0 {
+			return nil, false
+		}
+		fname := strings.TrimSpace(p[:colon])
+		ftype := strings.TrimSpace(p[colon+1:])
+		out = append(out, sparkColumnToFieldSchema(fname, ftype))
+	}
+	return out, true
+}
+
+// splitTopLevel splits s on sep, ignoring sep inside angle-bracket pairs.
+func splitTopLevel(s string, sep byte) []string {
+	var (
+		out   []string
+		depth int
+		start int
+	)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '<':
+			depth++
+		case '>':
+			if depth > 0 {
+				depth--
+			}
+		case sep:
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}
+
+// indexTopLevel returns the index of the first sep at depth 0, or -1.
+func indexTopLevel(s string, sep byte) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '<':
+			depth++
+		case '>':
+			if depth > 0 {
+				depth--
+			}
+		case sep:
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// normalizeSparkType lowercases and strips parameters from a Spark type string,
+// e.g., "varchar(64)" → "varchar", "decimal(10,2)" → "decimal".
+func normalizeSparkType(t string) string {
+	t = strings.ToLower(strings.TrimSpace(t))
+	if i := strings.IndexByte(t, '('); i >= 0 {
+		return strings.TrimSpace(t[:i])
+	}
+	return t
+}
+
+// Close is a no-op since we don't own the *sql.DB.
+func (tp *typeProvider) Close() {
+	// No-op: caller owns the *sql.DB connection.
+}
+
+// GetSchemas returns the schemas known to this type provider.
+func (tp *typeProvider) GetSchemas() map[string]Schema {
+	return tp.schemas
+}
+
+// EnumValue implements types.Provider.
+func (tp *typeProvider) EnumValue(_ string) ref.Val {
+	return types.NewErr("unknown enum value")
+}
+
+// FindIdent implements types.Provider.
+func (tp *typeProvider) FindIdent(_ string) (ref.Val, bool) {
+	return nil, false
+}
+
+// FindStructType implements types.Provider.
+func (tp *typeProvider) FindStructType(structType string) (*types.Type, bool) {
+	if _, ok := tp.schemas[structType]; ok {
+		return types.NewObjectType(structType), true
+	}
+	return nil, false
+}
+
+// FindStructFieldNames implements types.Provider.
+func (tp *typeProvider) FindStructFieldNames(structType string) ([]string, bool) {
+	s, ok := tp.schemas[structType]
+	if !ok {
+		return nil, false
+	}
+	fields := s.Fields()
+	names := make([]string, len(fields))
+	for i, f := range fields {
+		names[i] = f.Name
+	}
+	return names, true
+}
+
+// FindStructFieldType implements types.Provider.
+func (tp *typeProvider) FindStructFieldType(structType, fieldName string) (*types.FieldType, bool) {
+	s, ok := tp.schemas[structType]
+	if !ok {
+		return nil, false
+	}
+	field, found := s.FindField(fieldName)
+	if !found {
+		return nil, false
+	}
+	exprType := sparkTypeToCELExprType(field)
+	celType, err := types.ExprTypeToType(exprType)
+	if err != nil {
+		return nil, false
+	}
+	return &types.FieldType{Type: celType}, true
+}
+
+// NewValue implements types.Provider.
+func (tp *typeProvider) NewValue(_ string, _ map[string]ref.Val) ref.Val {
+	return types.NewErr("unknown type in schema")
+}
+
+// sparkTypeToCELExprType converts a Spark field schema to a CEL expression type.
+func sparkTypeToCELExprType(field *schema.FieldSchema) *exprpb.Type {
+	if field.Repeated {
+		return decls.NewListType(sparkBaseTypeToCEL(field.ElementType))
+	}
+	return sparkBaseTypeToCEL(field.Type)
+}
+
+// sparkBaseTypeToCEL converts a Spark type name to a CEL expression type.
+func sparkBaseTypeToCEL(typeName string) *exprpb.Type {
+	switch typeName {
+	case "string", "varchar", "char":
+		return decls.String
+	case "byte", "tinyint", "short", "smallint", "int", "integer", "long", "bigint":
+		return decls.Int
+	case "float", "double", "real", "decimal", "numeric":
+		return decls.Double
+	case "boolean", "bool":
+		return decls.Bool
+	case "binary":
+		return decls.Bytes
+	case "date":
+		return sqltypes.Date
+	case "timestamp", "timestamp_ntz":
+		return decls.Timestamp
+	default:
+		return decls.Dyn
+	}
+}

--- a/spark/provider.go
+++ b/spark/provider.go
@@ -82,6 +82,9 @@ func (tp *typeProvider) LoadTableSchema(ctx context.Context, tableName string) e
 		return fmt.Errorf("%w: no database connection available", ErrInvalidSchema)
 	}
 
+	// DESCRIBE TABLE does not accept parameterized table names; the name was validated
+	// against a strict identifier regex above, so the concatenation is safe.
+	// #nosec G202 -- table name validated against validTableName regex
 	query := "DESCRIBE TABLE " + tableName
 	rows, err := tp.db.QueryContext(ctx, query)
 	if err != nil {

--- a/spark/provider.go
+++ b/spark/provider.go
@@ -123,12 +123,12 @@ func (tp *typeProvider) LoadTableSchema(ctx context.Context, tableName string) e
 func sparkColumnToFieldSchema(name, dataType string) FieldSchema {
 	dt := strings.TrimSpace(strings.ToLower(dataType))
 
-	if isArr, elem := detectSparkArray(dt); isArr {
+	if isArr, elem, dims := detectSparkArray(dt); isArr {
 		return FieldSchema{
 			Name:        name,
 			Type:        normalizeSparkType(elem),
 			Repeated:    true,
-			Dimensions:  1,
+			Dimensions:  dims,
 			ElementType: normalizeSparkType(elem),
 		}
 	}
@@ -149,14 +149,22 @@ func sparkColumnToFieldSchema(name, dataType string) FieldSchema {
 }
 
 // detectSparkArray reports whether a Spark type string is array<T> and returns
-// the element type T. Nested arrays (array<array<T>>) collapse to dimension 1
-// in v1; multi-dimensional arrays are uncommon in Spark and unsupported by
-// the dialect emitter.
-func detectSparkArray(dt string) (isArray bool, elementType string) {
+// the (innermost) element type T plus the number of nested array<...> wrappers.
+// `array<int>` → (true, "int", 1); `array<array<int>>` → (true, "int", 2).
+// Multi-dimensional arrays are surfaced via Dimensions so the dialect emitter
+// can return ErrUnsupportedFeature on size() rather than silently treating the
+// outer array as 1D.
+func detectSparkArray(dt string) (isArray bool, elementType string, dimensions int) {
 	if !strings.HasPrefix(dt, "array<") || !strings.HasSuffix(dt, ">") {
-		return false, ""
+		return false, "", 0
 	}
-	return true, dt[len("array<") : len(dt)-1]
+	dims := 0
+	cur := dt
+	for strings.HasPrefix(cur, "array<") && strings.HasSuffix(cur, ">") {
+		dims++
+		cur = cur[len("array<") : len(cur)-1]
+	}
+	return true, cur, dims
 }
 
 // parseSparkStruct parses a Spark struct type string of the form
@@ -185,23 +193,31 @@ func parseSparkStruct(dt string) ([]FieldSchema, bool) {
 	return out, true
 }
 
-// splitTopLevel splits s on sep, ignoring sep inside angle-bracket pairs.
+// splitTopLevel splits s on sep, ignoring sep inside angle-bracket or
+// parenthesis pairs. Parenthesis tracking is needed for parameterized types
+// like decimal(10,2) appearing inside struct<…> definitions.
 func splitTopLevel(s string, sep byte) []string {
 	var (
-		out   []string
-		depth int
-		start int
+		out         []string
+		angle, paren int
+		start       int
 	)
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
 		case '<':
-			depth++
+			angle++
 		case '>':
-			if depth > 0 {
-				depth--
+			if angle > 0 {
+				angle--
+			}
+		case '(':
+			paren++
+		case ')':
+			if paren > 0 {
+				paren--
 			}
 		case sep:
-			if depth == 0 {
+			if angle == 0 && paren == 0 {
 				out = append(out, s[start:i])
 				start = i + 1
 			}
@@ -212,18 +228,25 @@ func splitTopLevel(s string, sep byte) []string {
 }
 
 // indexTopLevel returns the index of the first sep at depth 0, or -1.
+// Tracks both angle-bracket and parenthesis depth.
 func indexTopLevel(s string, sep byte) int {
-	depth := 0
+	var angle, paren int
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
 		case '<':
-			depth++
+			angle++
 		case '>':
-			if depth > 0 {
-				depth--
+			if angle > 0 {
+				angle--
+			}
+		case '(':
+			paren++
+		case ')':
+			if paren > 0 {
+				paren--
 			}
 		case sep:
-			if depth == 0 {
+			if angle == 0 && paren == 0 {
 				return i
 			}
 		}

--- a/spark/provider_test.go
+++ b/spark/provider_test.go
@@ -147,3 +147,69 @@ func TestLoadTableSchema_RejectsInvalidNames(t *testing.T) {
 		assert.ErrorIs(t, err, spark.ErrInvalidSchema)
 	}
 }
+
+func TestSparkColumnToFieldSchema(t *testing.T) {
+	tests := []struct {
+		name      string
+		dataType  string
+		want      spark.FieldSchema
+		wantField string // verifies one notable property; empty = compare full struct
+	}{
+		{
+			name:     "primitive int",
+			dataType: "int",
+			want:     spark.FieldSchema{Name: "c", Type: "int"},
+		},
+		{
+			name:     "decimal with params normalized",
+			dataType: "decimal(10,2)",
+			want:     spark.FieldSchema{Name: "c", Type: "decimal"},
+		},
+		{
+			name:     "varchar with size",
+			dataType: "varchar(64)",
+			want:     spark.FieldSchema{Name: "c", Type: "varchar"},
+		},
+		{
+			name:     "1d array",
+			dataType: "array<int>",
+			want: spark.FieldSchema{
+				Name: "c", Type: "int",
+				Repeated: true, Dimensions: 1, ElementType: "int",
+			},
+		},
+		{
+			name:     "2d nested array",
+			dataType: "array<array<int>>",
+			want: spark.FieldSchema{
+				Name: "c", Type: "int",
+				Repeated: true, Dimensions: 2, ElementType: "int",
+			},
+		},
+		{
+			name:     "3d nested array",
+			dataType: "array<array<array<string>>>",
+			want: spark.FieldSchema{
+				Name: "c", Type: "string",
+				Repeated: true, Dimensions: 3, ElementType: "string",
+			},
+		},
+		{
+			name:     "struct with parameterized types",
+			dataType: "struct<price:decimal(10,2),qty:int>",
+			want: spark.FieldSchema{
+				Name: "c", Type: "struct",
+				Schema: []spark.FieldSchema{
+					{Name: "price", Type: "decimal"},
+					{Name: "qty", Type: "int"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := spark.SparkColumnToFieldSchemaForTest("c", tt.dataType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/spark/provider_test.go
+++ b/spark/provider_test.go
@@ -1,0 +1,149 @@
+package spark_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spandigital/cel2sql/v3/spark"
+)
+
+func TestNewTypeProvider(t *testing.T) {
+	schemas := map[string]spark.Schema{
+		"users": spark.NewSchema([]spark.FieldSchema{
+			{Name: "id", Type: "bigint"},
+			{Name: "name", Type: "string"},
+		}),
+	}
+	provider := spark.NewTypeProvider(schemas)
+	require.NotNil(t, provider)
+
+	got := provider.GetSchemas()
+	assert.Len(t, got, 1)
+	assert.Contains(t, got, "users")
+}
+
+func TestNewTypeProviderWithConnection_NilDB(t *testing.T) {
+	_, err := spark.NewTypeProviderWithConnection(context.Background(), nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, spark.ErrInvalidSchema)
+}
+
+func TestLoadTableSchema_NoDB(t *testing.T) {
+	provider := spark.NewTypeProvider(nil)
+	err := provider.LoadTableSchema(context.Background(), "test")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, spark.ErrInvalidSchema)
+}
+
+func TestTypeProvider_FindStructType(t *testing.T) {
+	schemas := map[string]spark.Schema{
+		"users": spark.NewSchema([]spark.FieldSchema{
+			{Name: "id", Type: "bigint"},
+			{Name: "name", Type: "string"},
+		}),
+	}
+	provider := spark.NewTypeProvider(schemas)
+
+	typ, found := provider.FindStructType("users")
+	assert.True(t, found)
+	assert.NotNil(t, typ)
+
+	_, found = provider.FindStructType("nonexistent")
+	assert.False(t, found)
+}
+
+func TestTypeProvider_FindStructFieldNames(t *testing.T) {
+	schemas := map[string]spark.Schema{
+		"users": spark.NewSchema([]spark.FieldSchema{
+			{Name: "id", Type: "bigint"},
+			{Name: "name", Type: "string"},
+			{Name: "email", Type: "string"},
+		}),
+	}
+	provider := spark.NewTypeProvider(schemas)
+
+	names, found := provider.FindStructFieldNames("users")
+	assert.True(t, found)
+	assert.ElementsMatch(t, []string{"id", "name", "email"}, names)
+
+	_, found = provider.FindStructFieldNames("nonexistent")
+	assert.False(t, found)
+}
+
+func TestTypeProvider_FindStructFieldType(t *testing.T) {
+	schemas := map[string]spark.Schema{
+		"test_table": spark.NewSchema([]spark.FieldSchema{
+			{Name: "str_field", Type: "string"},
+			{Name: "varchar_field", Type: "varchar"},
+			{Name: "int_field", Type: "int"},
+			{Name: "bigint_field", Type: "bigint"},
+			{Name: "tinyint_field", Type: "tinyint"},
+			{Name: "double_field", Type: "double"},
+			{Name: "float_field", Type: "float"},
+			{Name: "decimal_field", Type: "decimal"},
+			{Name: "bool_field", Type: "boolean"},
+			{Name: "binary_field", Type: "binary"},
+			{Name: "ts_field", Type: "timestamp"},
+			{Name: "ts_ntz_field", Type: "timestamp_ntz"},
+			{Name: "tags", Type: "string", Repeated: true, ElementType: "string"},
+			{Name: "scores", Type: "bigint", Repeated: true, ElementType: "bigint"},
+		}),
+	}
+	provider := spark.NewTypeProvider(schemas)
+
+	tests := []struct {
+		fieldName string
+		wantType  *types.Type
+		wantFound bool
+	}{
+		{"str_field", types.StringType, true},
+		{"varchar_field", types.StringType, true},
+		{"int_field", types.IntType, true},
+		{"bigint_field", types.IntType, true},
+		{"tinyint_field", types.IntType, true},
+		{"double_field", types.DoubleType, true},
+		{"float_field", types.DoubleType, true},
+		{"decimal_field", types.DoubleType, true},
+		{"bool_field", types.BoolType, true},
+		{"binary_field", types.BytesType, true},
+		{"ts_field", types.TimestampType, true},
+		{"ts_ntz_field", types.TimestampType, true},
+		{"tags", types.NewListType(types.StringType), true},
+		{"scores", types.NewListType(types.IntType), true},
+		{"nonexistent", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.fieldName, func(t *testing.T) {
+			got, found := provider.FindStructFieldType("test_table", tt.fieldName)
+			assert.Equal(t, tt.wantFound, found)
+			if found {
+				assert.Equal(t, tt.wantType, got.Type)
+			}
+		})
+	}
+}
+
+func TestTypeProvider_Close(_ *testing.T) {
+	provider := spark.NewTypeProvider(nil)
+	// Close should not panic.
+	provider.Close()
+}
+
+func TestLoadTableSchema_RejectsInvalidNames(t *testing.T) {
+	// We don't need a real DB: invalid names short-circuit before any query.
+	provider := spark.NewTypeProvider(nil)
+	for _, bad := range []string{
+		"users; DROP TABLE users",
+		"users--",
+		"' OR '1'='1",
+		"",
+	} {
+		err := provider.LoadTableSchema(context.Background(), bad)
+		require.Error(t, err, "expected error for input %q", bad)
+		assert.ErrorIs(t, err, spark.ErrInvalidSchema)
+	}
+}

--- a/testcases/array_tests.go
+++ b/testcases/array_tests.go
@@ -13,6 +13,7 @@ func ArrayTests() []ConvertTestCase {
 				dialect.PostgreSQL: "ARRAY[1, 2, 3][1] = 1",
 				dialect.DuckDB:     "[1, 2, 3][1] = 1",
 				dialect.BigQuery:   "[1, 2, 3][OFFSET(0)] = 1",
+				dialect.Spark:      "array(1, 2, 3)[0] = 1",
 			},
 		},
 		{
@@ -23,6 +24,7 @@ func ArrayTests() []ConvertTestCase {
 				dialect.PostgreSQL: "string_list[1] = 'a'",
 				dialect.DuckDB:     "string_list[1] = 'a'",
 				dialect.BigQuery:   "string_list[OFFSET(0)] = 'a'",
+				dialect.Spark:      "string_list[0] = 'a'",
 			},
 		},
 		{
@@ -33,6 +35,7 @@ func ArrayTests() []ConvertTestCase {
 				dialect.PostgreSQL: "COALESCE(ARRAY_LENGTH(string_list, 1), 0)",
 				dialect.DuckDB:     "COALESCE(array_length(string_list), 0)",
 				dialect.BigQuery:   "ARRAY_LENGTH(string_list)",
+				dialect.Spark:      "COALESCE(size(string_list), 0)",
 			},
 		},
 		{
@@ -43,6 +46,7 @@ func ArrayTests() []ConvertTestCase {
 				dialect.PostgreSQL: "COALESCE(ARRAY_LENGTH(string_list, 1), 0) > 0",
 				dialect.DuckDB:     "COALESCE(array_length(string_list), 0) > 0",
 				dialect.BigQuery:   "ARRAY_LENGTH(string_list) > 0",
+				dialect.Spark:      "COALESCE(size(string_list), 0) > 0",
 			},
 		},
 		{
@@ -53,6 +57,7 @@ func ArrayTests() []ConvertTestCase {
 				dialect.PostgreSQL: true,
 				dialect.DuckDB:     true,
 				dialect.BigQuery:   true,
+				dialect.Spark:      true,
 			},
 		},
 		{
@@ -63,6 +68,7 @@ func ArrayTests() []ConvertTestCase {
 				dialect.PostgreSQL: true,
 				dialect.DuckDB:     true,
 				dialect.BigQuery:   true,
+				dialect.Spark:      true,
 			},
 		},
 	}

--- a/testcases/basic_tests.go
+++ b/testcases/basic_tests.go
@@ -15,6 +15,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "name = 'a'",
 				dialect.DuckDB:     "name = 'a'",
 				dialect.BigQuery:   "name = 'a'",
+				dialect.Spark:      "name = 'a'",
 			},
 		},
 		{
@@ -27,6 +28,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "age != 20",
 				dialect.DuckDB:     "age != 20",
 				dialect.BigQuery:   "age != 20",
+				dialect.Spark:      "age != 20",
 			},
 		},
 		{
@@ -39,6 +41,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "age < 20",
 				dialect.DuckDB:     "age < 20",
 				dialect.BigQuery:   "age < 20",
+				dialect.Spark:      "age < 20",
 			},
 		},
 		{
@@ -51,6 +54,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "height >= 1.6180339887",
 				dialect.DuckDB:     "height >= 1.6180339887",
 				dialect.BigQuery:   "height >= 1.6180339887",
+				dialect.Spark:      "height >= 1.6180339887",
 			},
 		},
 		{
@@ -63,6 +67,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "null_var IS NULL",
 				dialect.DuckDB:     "null_var IS NULL",
 				dialect.BigQuery:   "null_var IS NULL",
+				dialect.Spark:      "null_var IS NULL",
 			},
 		},
 		{
@@ -75,6 +80,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "adult IS NOT TRUE",
 				dialect.DuckDB:     "adult IS NOT TRUE",
 				dialect.BigQuery:   "adult IS NOT TRUE",
+				dialect.Spark:      "adult IS NOT TRUE",
 			},
 		},
 		{
@@ -87,6 +93,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "NOT adult",
 				dialect.DuckDB:     "NOT adult",
 				dialect.BigQuery:   "NOT adult",
+				dialect.Spark:      "NOT adult",
 			},
 		},
 		{
@@ -99,6 +106,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "-1",
 				dialect.DuckDB:     "-1",
 				dialect.BigQuery:   "-1",
+				dialect.Spark:      "-1",
 			},
 		},
 		{
@@ -111,6 +119,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "CASE WHEN name = 'a' THEN 'a' ELSE 'b' END",
 				dialect.DuckDB:     "CASE WHEN name = 'a' THEN 'a' ELSE 'b' END",
 				dialect.BigQuery:   "CASE WHEN name = 'a' THEN 'a' ELSE 'b' END",
+				dialect.Spark:      "CASE WHEN name = 'a' THEN 'a' ELSE 'b' END",
 			},
 		},
 		{
@@ -123,6 +132,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "page.title = 'test'",
 				dialect.DuckDB:     "page.title = 'test'",
 				dialect.BigQuery:   "page.title = 'test'",
+				dialect.Spark:      "page.title = 'test'",
 			},
 		},
 		{
@@ -135,6 +145,7 @@ func BasicTests() []ConvertTestCase {
 				dialect.SQLite:     "name IN (SELECT value FROM json_each(json_array('a', 'b', 'c')))",
 				dialect.DuckDB:     "name = ANY(['a', 'b', 'c'])",
 				dialect.BigQuery:   "name IN UNNEST(['a', 'b', 'c'])",
+				dialect.Spark:      "array_contains(array('a', 'b', 'c'), name)",
 			},
 		},
 	}

--- a/testcases/cast_tests.go
+++ b/testcases/cast_tests.go
@@ -15,6 +15,7 @@ func CastTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST(0 AS INTEGER) IS FALSE",
 				dialect.DuckDB:     "CAST(0 AS BOOLEAN) IS FALSE",
 				dialect.BigQuery:   "CAST(0 AS BOOL) IS FALSE",
+				dialect.Spark:      "CAST(0 AS BOOLEAN) IS FALSE",
 			},
 		},
 		{
@@ -27,6 +28,7 @@ func CastTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST('test' AS BLOB)",
 				dialect.DuckDB:     "CAST('test' AS BLOB)",
 				dialect.BigQuery:   "CAST('test' AS BYTES)",
+				dialect.Spark:      "CAST('test' AS BINARY)",
 			},
 		},
 		{
@@ -39,6 +41,7 @@ func CastTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST(TRUE AS INTEGER) = 1",
 				dialect.DuckDB:     "CAST(TRUE AS BIGINT) = 1",
 				dialect.BigQuery:   "CAST(TRUE AS INT64) = 1",
+				dialect.Spark:      "CAST(TRUE AS BIGINT) = 1",
 			},
 		},
 		{
@@ -51,6 +54,7 @@ func CastTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST(TRUE AS TEXT) = 'true'",
 				dialect.DuckDB:     "CAST(TRUE AS VARCHAR) = 'true'",
 				dialect.BigQuery:   "CAST(TRUE AS STRING) = 'true'",
+				dialect.Spark:      "CAST(TRUE AS STRING) = 'true'",
 			},
 		},
 		{
@@ -63,6 +67,7 @@ func CastTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST(created_at AS TEXT)",
 				dialect.DuckDB:     "CAST(created_at AS VARCHAR)",
 				dialect.BigQuery:   "CAST(created_at AS STRING)",
+				dialect.Spark:      "CAST(created_at AS STRING)",
 			},
 		},
 		{
@@ -75,6 +80,7 @@ func CastTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST(strftime('%s', created_at) AS INTEGER)",
 				dialect.DuckDB:     "EXTRACT(EPOCH FROM created_at)::BIGINT",
 				dialect.BigQuery:   "UNIX_SECONDS(created_at)",
+				dialect.Spark:      "UNIX_TIMESTAMP(created_at)",
 			},
 		},
 	}

--- a/testcases/comprehension_tests.go
+++ b/testcases/comprehension_tests.go
@@ -14,6 +14,7 @@ func ComprehensionTests() []ConvertTestCase {
 				dialect.SQLite:     "NOT EXISTS (SELECT 1 FROM json_each(string_list) AS x WHERE NOT (x != 'bad'))",
 				dialect.DuckDB:     "NOT EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE NOT (x != 'bad'))",
 				dialect.BigQuery:   "NOT EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE NOT (x != 'bad'))",
+				dialect.Spark:      "NOT EXISTS (SELECT 1 FROM EXPLODE(string_list) AS x WHERE NOT (x != 'bad'))",
 			},
 		},
 		{
@@ -25,6 +26,7 @@ func ComprehensionTests() []ConvertTestCase {
 				dialect.SQLite:     "EXISTS (SELECT 1 FROM json_each(string_list) AS x WHERE x = 'good')",
 				dialect.DuckDB:     "EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE x = 'good')",
 				dialect.BigQuery:   "EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE x = 'good')",
+				dialect.Spark:      "EXISTS (SELECT 1 FROM EXPLODE(string_list) AS x WHERE x = 'good')",
 			},
 		},
 		{
@@ -36,6 +38,7 @@ func ComprehensionTests() []ConvertTestCase {
 				dialect.SQLite:     "(SELECT COUNT(*) FROM json_each(string_list) AS x WHERE x = 'unique') = 1",
 				dialect.DuckDB:     "(SELECT COUNT(*) FROM UNNEST(string_list) AS x WHERE x = 'unique') = 1",
 				dialect.BigQuery:   "(SELECT COUNT(*) FROM UNNEST(string_list) AS x WHERE x = 'unique') = 1",
+				dialect.Spark:      "(SELECT COUNT(*) FROM EXPLODE(string_list) AS x WHERE x = 'unique') = 1",
 			},
 		},
 		{
@@ -47,6 +50,7 @@ func ComprehensionTests() []ConvertTestCase {
 				dialect.SQLite:     "(SELECT json_group_array(x) FROM json_each(string_list) AS x WHERE x != 'bad')",
 				dialect.DuckDB:     "ARRAY(SELECT x FROM UNNEST(string_list) AS x WHERE x != 'bad')",
 				dialect.BigQuery:   "ARRAY(SELECT x FROM UNNEST(string_list) AS x WHERE x != 'bad')",
+				dialect.Spark:      "(SELECT collect_list(x) FROM EXPLODE(string_list) AS x WHERE x != 'bad')",
 			},
 		},
 		{
@@ -58,6 +62,7 @@ func ComprehensionTests() []ConvertTestCase {
 				dialect.SQLite:     "(SELECT json_group_array(x || '_suffix') FROM json_each(string_list) AS x)",
 				dialect.DuckDB:     "ARRAY(SELECT x || '_suffix' FROM UNNEST(string_list) AS x)",
 				dialect.BigQuery:   "ARRAY(SELECT x || '_suffix' FROM UNNEST(string_list) AS x)",
+				dialect.Spark:      "(SELECT collect_list(concat(x, '_suffix')) FROM EXPLODE(string_list) AS x)",
 			},
 		},
 	}

--- a/testcases/json_tests.go
+++ b/testcases/json_tests.go
@@ -17,6 +17,7 @@ func JSONTests() []ConvertTestCase {
 				dialect.SQLite:     "json_extract(product.metadata, '$.brand') = 'Acme'",
 				dialect.DuckDB:     "product.metadata->>'brand' = 'Acme'",
 				dialect.BigQuery:   "JSON_VALUE(product.metadata, '$.brand') = 'Acme'",
+				dialect.Spark:      "get_json_object(product.metadata, '$.brand') = 'Acme'",
 			},
 		},
 		{
@@ -30,6 +31,7 @@ func JSONTests() []ConvertTestCase {
 				dialect.SQLite:     "json_extract(json_extract(product.metadata, '$.specs'), '$.color') = 'red'",
 				dialect.DuckDB:     "product.metadata->'specs'->>'color' = 'red'",
 				dialect.BigQuery:   "JSON_VALUE(JSON_QUERY(product.metadata, '$.specs'), '$.color') = 'red'",
+				dialect.Spark:      "get_json_object(get_json_object(product.metadata, '$.specs'), '$.color') = 'red'",
 			},
 		},
 		{
@@ -43,6 +45,7 @@ func JSONTests() []ConvertTestCase {
 				dialect.SQLite:     "json_type(product.metadata, '$.brand') IS NOT NULL",
 				dialect.DuckDB:     "json_exists(product.metadata, '$.brand')",
 				dialect.BigQuery:   "JSON_VALUE(product.metadata, '$.brand') IS NOT NULL",
+				dialect.Spark:      "get_json_object(product.metadata, '$.brand') IS NOT NULL",
 			},
 		},
 	}

--- a/testcases/operator_tests.go
+++ b/testcases/operator_tests.go
@@ -15,6 +15,7 @@ func OperatorTests() []ConvertTestCase {
 				dialect.SQLite:     "name = 'a' AND age > 20",
 				dialect.DuckDB:     "name = 'a' AND age > 20",
 				dialect.BigQuery:   "name = 'a' AND age > 20",
+				dialect.Spark:      "name = 'a' AND age > 20",
 			},
 		},
 		{
@@ -27,6 +28,7 @@ func OperatorTests() []ConvertTestCase {
 				dialect.SQLite:     "name = 'a' OR age > 20",
 				dialect.DuckDB:     "name = 'a' OR age > 20",
 				dialect.BigQuery:   "name = 'a' OR age > 20",
+				dialect.Spark:      "name = 'a' OR age > 20",
 			},
 		},
 		{
@@ -39,6 +41,7 @@ func OperatorTests() []ConvertTestCase {
 				dialect.SQLite:     "age >= 10 AND (name = 'a' OR name = 'b')",
 				dialect.DuckDB:     "age >= 10 AND (name = 'a' OR name = 'b')",
 				dialect.BigQuery:   "age >= 10 AND (name = 'a' OR name = 'b')",
+				dialect.Spark:      "age >= 10 AND (name = 'a' OR name = 'b')",
 			},
 		},
 		{
@@ -51,6 +54,7 @@ func OperatorTests() []ConvertTestCase {
 				dialect.SQLite:     "1 + 2 = 3",
 				dialect.DuckDB:     "1 + 2 = 3",
 				dialect.BigQuery:   "1 + 2 = 3",
+				dialect.Spark:      "1 + 2 = 3",
 			},
 		},
 		{
@@ -63,6 +67,7 @@ func OperatorTests() []ConvertTestCase {
 				dialect.SQLite:     "MOD(5, 3) = 2",
 				dialect.DuckDB:     "MOD(5, 3) = 2",
 				dialect.BigQuery:   "MOD(5, 3) = 2",
+				dialect.Spark:      "MOD(5, 3) = 2",
 			},
 		},
 		{
@@ -75,6 +80,7 @@ func OperatorTests() []ConvertTestCase {
 				dialect.SQLite:     "'a' || 'b' = 'ab'",
 				dialect.DuckDB:     "'a' || 'b' = 'ab'",
 				dialect.BigQuery:   "'a' || 'b' = 'ab'",
+				dialect.Spark:      "concat('a', 'b') = 'ab'",
 			},
 		},
 		{
@@ -85,6 +91,7 @@ func OperatorTests() []ConvertTestCase {
 				dialect.PostgreSQL: "1 = ANY(ARRAY[1] || ARRAY[2, 3])",
 				dialect.DuckDB:     "1 = ANY([1] || [2, 3])",
 				dialect.BigQuery:   "1 IN UNNEST([1] || [2, 3])",
+				dialect.Spark:      "array_contains(array(1) || array(2, 3), 1)",
 			},
 		},
 	}

--- a/testcases/parameterized_tests.go
+++ b/testcases/parameterized_tests.go
@@ -14,12 +14,14 @@ func ParameterizedTests() []ParameterizedTestCase {
 				dialect.SQLite:     "name = ?",
 				dialect.DuckDB:     "name = $1",
 				dialect.BigQuery:   "name = @p1",
+				dialect.Spark:      "name = ?",
 			},
 			WantParams: map[dialect.Name][]any{
 				dialect.PostgreSQL: {"John"},
 				dialect.SQLite:     {"John"},
 				dialect.DuckDB:     {"John"},
 				dialect.BigQuery:   {"John"},
+				dialect.Spark:      {"John"},
 			},
 		},
 		{
@@ -31,12 +33,14 @@ func ParameterizedTests() []ParameterizedTestCase {
 				dialect.SQLite:     "name = ? AND name != ?",
 				dialect.DuckDB:     "name = $1 AND name != $2",
 				dialect.BigQuery:   "name = @p1 AND name != @p2",
+				dialect.Spark:      "name = ? AND name != ?",
 			},
 			WantParams: map[dialect.Name][]any{
 				dialect.PostgreSQL: {"John", "Jane"},
 				dialect.SQLite:     {"John", "Jane"},
 				dialect.DuckDB:     {"John", "Jane"},
 				dialect.BigQuery:   {"John", "Jane"},
+				dialect.Spark:      {"John", "Jane"},
 			},
 		},
 		{
@@ -48,12 +52,14 @@ func ParameterizedTests() []ParameterizedTestCase {
 				dialect.SQLite:     "age = ?",
 				dialect.DuckDB:     "age = $1",
 				dialect.BigQuery:   "age = @p1",
+				dialect.Spark:      "age = ?",
 			},
 			WantParams: map[dialect.Name][]any{
 				dialect.PostgreSQL: {int64(18)},
 				dialect.SQLite:     {int64(18)},
 				dialect.DuckDB:     {int64(18)},
 				dialect.BigQuery:   {int64(18)},
+				dialect.Spark:      {int64(18)},
 			},
 		},
 		{
@@ -65,12 +71,14 @@ func ParameterizedTests() []ParameterizedTestCase {
 				dialect.SQLite:     "age > ? AND age < ?",
 				dialect.DuckDB:     "age > $1 AND age < $2",
 				dialect.BigQuery:   "age > @p1 AND age < @p2",
+				dialect.Spark:      "age > ? AND age < ?",
 			},
 			WantParams: map[dialect.Name][]any{
 				dialect.PostgreSQL: {int64(21), int64(65)},
 				dialect.SQLite:     {int64(21), int64(65)},
 				dialect.DuckDB:     {int64(21), int64(65)},
 				dialect.BigQuery:   {int64(21), int64(65)},
+				dialect.Spark:      {int64(21), int64(65)},
 			},
 		},
 		{
@@ -82,12 +90,14 @@ func ParameterizedTests() []ParameterizedTestCase {
 				dialect.SQLite:     "salary = ?",
 				dialect.DuckDB:     "salary = $1",
 				dialect.BigQuery:   "salary = @p1",
+				dialect.Spark:      "salary = ?",
 			},
 			WantParams: map[dialect.Name][]any{
 				dialect.PostgreSQL: {50000.50},
 				dialect.SQLite:     {50000.50},
 				dialect.DuckDB:     {50000.50},
 				dialect.BigQuery:   {50000.50},
+				dialect.Spark:      {50000.50},
 			},
 		},
 		{
@@ -99,12 +109,14 @@ func ParameterizedTests() []ParameterizedTestCase {
 				dialect.SQLite:     "active IS TRUE",
 				dialect.DuckDB:     "active IS TRUE",
 				dialect.BigQuery:   "active IS TRUE",
+				dialect.Spark:      "active IS TRUE",
 			},
 			WantParams: map[dialect.Name][]any{
 				dialect.PostgreSQL: {},
 				dialect.SQLite:     {},
 				dialect.DuckDB:     {},
 				dialect.BigQuery:   {},
+				dialect.Spark:      {},
 			},
 		},
 	}

--- a/testcases/regex_tests.go
+++ b/testcases/regex_tests.go
@@ -14,6 +14,7 @@ func RegexTests() []ConvertTestCase {
 				dialect.MySQL:      "name REGEXP 'a+'",
 				dialect.DuckDB:     "name ~ 'a+'",
 				dialect.BigQuery:   "REGEXP_CONTAINS(name, 'a+')",
+				dialect.Spark:      "name RLIKE 'a+'",
 			},
 			SkipDialect: map[dialect.Name]string{
 				dialect.SQLite: "SQLite does not support regex",
@@ -28,6 +29,7 @@ func RegexTests() []ConvertTestCase {
 				dialect.MySQL:      "name REGEXP '^[0-9]+$'",
 				dialect.DuckDB:     "name ~ '^[0-9]+$'",
 				dialect.BigQuery:   "REGEXP_CONTAINS(name, '^[0-9]+$')",
+				dialect.Spark:      "name RLIKE '^[0-9]+$'",
 			},
 			SkipDialect: map[dialect.Name]string{
 				dialect.SQLite: "SQLite does not support regex",
@@ -42,6 +44,7 @@ func RegexTests() []ConvertTestCase {
 				dialect.MySQL:      "name REGEXP '\\btest\\b'",
 				dialect.DuckDB:     "name ~ '\\btest\\b'",
 				dialect.BigQuery:   "REGEXP_CONTAINS(name, '\\btest\\b')",
+				dialect.Spark:      "name RLIKE '\\btest\\b'",
 			},
 			SkipDialect: map[dialect.Name]string{
 				dialect.SQLite: "SQLite does not support regex",
@@ -56,6 +59,7 @@ func RegexTests() []ConvertTestCase {
 				dialect.MySQL:      "name REGEXP '\\d{3}-\\d{4}'",
 				dialect.DuckDB:     "name ~ '\\d{3}-\\d{4}'",
 				dialect.BigQuery:   "REGEXP_CONTAINS(name, '\\d{3}-\\d{4}')",
+				dialect.Spark:      "name RLIKE '\\d{3}-\\d{4}'",
 			},
 			SkipDialect: map[dialect.Name]string{
 				dialect.SQLite: "SQLite does not support regex",
@@ -70,6 +74,7 @@ func RegexTests() []ConvertTestCase {
 				dialect.MySQL:      "name REGEXP '\\w+@\\w+\\.\\w+'",
 				dialect.DuckDB:     "name ~ '\\w+@\\w+\\.\\w+'",
 				dialect.BigQuery:   "REGEXP_CONTAINS(name, '\\w+@\\w+\\.\\w+')",
+				dialect.Spark:      "name RLIKE '\\w+@\\w+\\.\\w+'",
 			},
 			SkipDialect: map[dialect.Name]string{
 				dialect.SQLite: "SQLite does not support regex",
@@ -84,6 +89,7 @@ func RegexTests() []ConvertTestCase {
 				dialect.MySQL:      "name REGEXP '.*pattern.*'",
 				dialect.DuckDB:     "name ~ '.*pattern.*'",
 				dialect.BigQuery:   "REGEXP_CONTAINS(name, '.*pattern.*')",
+				dialect.Spark:      "name RLIKE '.*pattern.*'",
 			},
 			SkipDialect: map[dialect.Name]string{
 				dialect.SQLite: "SQLite does not support regex",

--- a/testcases/string_tests.go
+++ b/testcases/string_tests.go
@@ -15,6 +15,7 @@ func StringTests() []ConvertTestCase {
 				dialect.SQLite:     "name LIKE 'a%' ESCAPE '\\'",
 				dialect.DuckDB:     "name LIKE 'a%' ESCAPE '\\\\'",
 				dialect.BigQuery:   "name LIKE 'a%'",
+				dialect.Spark:      "name LIKE 'a%' ESCAPE '\\\\'",
 			},
 		},
 		{
@@ -27,6 +28,7 @@ func StringTests() []ConvertTestCase {
 				dialect.SQLite:     "name LIKE '%z' ESCAPE '\\'",
 				dialect.DuckDB:     "name LIKE '%z' ESCAPE '\\\\'",
 				dialect.BigQuery:   "name LIKE '%z'",
+				dialect.Spark:      "name LIKE '%z' ESCAPE '\\\\'",
 			},
 		},
 		{
@@ -39,6 +41,7 @@ func StringTests() []ConvertTestCase {
 				dialect.SQLite:     "INSTR(name, 'abc') > 0",
 				dialect.DuckDB:     "CONTAINS(name, 'abc')",
 				dialect.BigQuery:   "STRPOS(name, 'abc') > 0",
+				dialect.Spark:      "LOCATE('abc', name) > 0",
 			},
 		},
 		{
@@ -51,6 +54,7 @@ func StringTests() []ConvertTestCase {
 				dialect.SQLite:     "LENGTH('test')",
 				dialect.DuckDB:     "LENGTH('test')",
 				dialect.BigQuery:   "LENGTH('test')",
+				dialect.Spark:      "LENGTH('test')",
 			},
 		},
 		{
@@ -63,6 +67,7 @@ func StringTests() []ConvertTestCase {
 				dialect.SQLite:     "name LIKE 'a%' ESCAPE '\\' AND name LIKE '%z' ESCAPE '\\'",
 				dialect.DuckDB:     "name LIKE 'a%' ESCAPE '\\\\' AND name LIKE '%z' ESCAPE '\\\\'",
 				dialect.BigQuery:   "name LIKE 'a%' AND name LIKE '%z'",
+				dialect.Spark:      "name LIKE 'a%' ESCAPE '\\\\' AND name LIKE '%z' ESCAPE '\\\\'",
 			},
 		},
 	}

--- a/testcases/timestamp_tests.go
+++ b/testcases/timestamp_tests.go
@@ -15,6 +15,7 @@ func TimestampTests() []ConvertTestCase {
 				dialect.SQLite:     "'+10 seconds'",
 				dialect.DuckDB:     "INTERVAL 10 SECOND",
 				dialect.BigQuery:   "INTERVAL 10 SECOND",
+				dialect.Spark:      "INTERVAL 10 SECOND",
 			},
 		},
 		{
@@ -27,6 +28,7 @@ func TimestampTests() []ConvertTestCase {
 				dialect.SQLite:     "'+61 minutes'",
 				dialect.DuckDB:     "INTERVAL 61 MINUTE",
 				dialect.BigQuery:   "INTERVAL 61 MINUTE",
+				dialect.Spark:      "INTERVAL 61 MINUTE",
 			},
 		},
 		{
@@ -39,6 +41,7 @@ func TimestampTests() []ConvertTestCase {
 				dialect.SQLite:     "'+1 hours'",
 				dialect.DuckDB:     "INTERVAL 1 HOUR",
 				dialect.BigQuery:   "INTERVAL 1 HOUR",
+				dialect.Spark:      "INTERVAL 1 HOUR",
 			},
 		},
 		{
@@ -51,6 +54,7 @@ func TimestampTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST(strftime('%S', created_at) AS INTEGER)",
 				dialect.DuckDB:     "EXTRACT(SECOND FROM created_at)",
 				dialect.BigQuery:   "EXTRACT(SECOND FROM created_at)",
+				dialect.Spark:      "EXTRACT(SECOND FROM created_at)",
 			},
 		},
 		{
@@ -63,6 +67,7 @@ func TimestampTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST(strftime('%H', created_at) AS INTEGER)",
 				dialect.DuckDB:     "EXTRACT(HOUR FROM created_at AT TIME ZONE 'Asia/Tokyo')",
 				dialect.BigQuery:   "EXTRACT(HOUR FROM created_at AT TIME ZONE 'Asia/Tokyo')",
+				dialect.Spark:      "EXTRACT(HOUR FROM created_at AT TIME ZONE 'Asia/Tokyo')",
 			},
 		},
 		{
@@ -75,6 +80,7 @@ func TimestampTests() []ConvertTestCase {
 				dialect.SQLite:     "datetime(created_at, '-'||'+1 hours') <= datetime('2021-09-01T18:00:00Z')",
 				dialect.DuckDB:     "created_at - INTERVAL 1 HOUR <= CAST('2021-09-01T18:00:00Z' AS TIMESTAMPTZ)",
 				dialect.BigQuery:   "TIMESTAMP_SUB(created_at, INTERVAL 1 HOUR) <= CAST('2021-09-01T18:00:00Z' AS TIMESTAMP)",
+				dialect.Spark:      "created_at - INTERVAL 1 HOUR <= CAST('2021-09-01T18:00:00Z' AS TIMESTAMP)",
 			},
 		},
 		{
@@ -88,6 +94,7 @@ func TimestampTests() []ConvertTestCase {
 				dialect.SQLite:     "'+'||1||' months'",
 				dialect.DuckDB:     "INTERVAL 1 MONTH",
 				dialect.BigQuery:   "INTERVAL 1 MONTH",
+				dialect.Spark:      "INTERVAL 1 MONTH",
 			},
 		},
 		{
@@ -101,6 +108,7 @@ func TimestampTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST(strftime('%Y', birthday) AS INTEGER)",
 				dialect.DuckDB:     "EXTRACT(YEAR FROM birthday)",
 				dialect.BigQuery:   "EXTRACT(YEAR FROM birthday)",
+				dialect.Spark:      "EXTRACT(YEAR FROM birthday)",
 			},
 		},
 		{
@@ -114,6 +122,7 @@ func TimestampTests() []ConvertTestCase {
 				dialect.SQLite:     "CAST(strftime('%m', scheduled_at) AS INTEGER) - 1",
 				dialect.DuckDB:     "EXTRACT(MONTH FROM scheduled_at) - 1",
 				dialect.BigQuery:   "EXTRACT(MONTH FROM scheduled_at) - 1",
+				dialect.Spark:      "EXTRACT(MONTH FROM scheduled_at) - 1",
 			},
 		},
 	}

--- a/testutil/env.go
+++ b/testutil/env.go
@@ -10,6 +10,7 @@ import (
 	bigqueryDialect "github.com/spandigital/cel2sql/v3/dialect/bigquery"
 	duckdbDialect "github.com/spandigital/cel2sql/v3/dialect/duckdb"
 	mysqlDialect "github.com/spandigital/cel2sql/v3/dialect/mysql"
+	sparkDialect "github.com/spandigital/cel2sql/v3/dialect/spark"
 	sqliteDialect "github.com/spandigital/cel2sql/v3/dialect/sqlite"
 	"github.com/spandigital/cel2sql/v3/pg"
 	"github.com/spandigital/cel2sql/v3/sqltypes"
@@ -288,6 +289,39 @@ func BigQueryEnvFactory() func(envSetup string) (*EnvResult, error) {
 	}
 }
 
+// SparkEnvFactory returns an environment factory for Spark SQL tests.
+// It uses the same CEL environments as PostgreSQL (CEL compilation is dialect-independent)
+// but sets the Spark dialect for SQL generation.
+func SparkEnvFactory() func(envSetup string) (*EnvResult, error) {
+	return func(envSetup string) (*EnvResult, error) {
+		switch envSetup {
+		case testcases.EnvDefault:
+			result, err := NewDefaultEnv()
+			if err != nil {
+				return nil, err
+			}
+			result.Opts = append(result.Opts, cel2sql.WithDialect(sparkDialect.New()))
+			return result, nil
+		case testcases.EnvWithTimestamp:
+			result, err := NewTimestampEnv()
+			if err != nil {
+				return nil, err
+			}
+			result.Opts = append(result.Opts, cel2sql.WithDialect(sparkDialect.New()))
+			return result, nil
+		case testcases.EnvWithJSON:
+			result, err := NewJSONSchemaEnv()
+			if err != nil {
+				return nil, err
+			}
+			result.Opts = append(result.Opts, cel2sql.WithDialect(sparkDialect.New()))
+			return result, nil
+		default:
+			return nil, fmt.Errorf("unknown environment setup: %s", envSetup)
+		}
+	}
+}
+
 // DialectEnvFactory returns an environment factory for the given dialect.
 // This is a convenience function that maps dialect names to their env factories.
 func DialectEnvFactory(d dialectpkg.Name) func(envSetup string) (*EnvResult, error) {
@@ -302,6 +336,8 @@ func DialectEnvFactory(d dialectpkg.Name) func(envSetup string) (*EnvResult, err
 		return DuckDBEnvFactory()
 	case dialectpkg.BigQuery:
 		return BigQueryEnvFactory()
+	case dialectpkg.Spark:
+		return SparkEnvFactory()
 	default:
 		return func(_ string) (*EnvResult, error) {
 			return nil, fmt.Errorf("no environment factory for dialect %s", d)

--- a/testutil/runner_spark_test.go
+++ b/testutil/runner_spark_test.go
@@ -1,0 +1,16 @@
+package testutil_test
+
+import (
+	"testing"
+
+	"github.com/spandigital/cel2sql/v3/dialect"
+	"github.com/spandigital/cel2sql/v3/testutil"
+)
+
+func TestSparkSharedCases(t *testing.T) {
+	testutil.RunAllConvertTests(t, dialect.Spark, testutil.SparkEnvFactory())
+}
+
+func TestSparkParameterizedSharedCases(t *testing.T) {
+	testutil.RunAllParameterizedTests(t, dialect.Spark, testutil.SparkEnvFactory())
+}


### PR DESCRIPTION
## Summary

Sixth supported SQL dialect, alongside PostgreSQL/MySQL/SQLite/DuckDB/BigQuery. Spark is the most widely used analytic SQL engine in the Hadoop/Lakehouse ecosystem (Databricks, EMR, Synapse, OSS Spark on Iceberg/Delta/Parquet).

```go
import "github.com/spandigital/cel2sql/v3/dialect/spark"

sql, err := cel2sql.Convert(ast, cel2sql.WithDialect(spark.New()))
// CEL: tags.color == "blue" && age > 18
// SQL: get_json_object(tags, '$.color') = 'blue' AND age > 18
```

### What's in this PR

- **`dialect/spark/`** — full `dialect.Dialect` implementation
  - Backticks for identifiers, `?` positional placeholders, `RLIKE` for regex, `get_json_object()` for JSON, `array(...)` function literals, **0-indexed** array access (Java/Scala convention), `named_struct()`, `EXPLODE` for `UNNEST`, `collect_list()` for `ARRAY(SELECT …)` subqueries.
  - `dayofweek(expr) - 1` to convert Spark's Sunday=1 convention to CEL's Sunday=0.
  - Java regex passthrough — Spark accepts `\d`, `\w`, `\s`, `\b`, and `(?i)` inline natively, so no POSIX translation is needed. Same ReDoS validators as other dialects (length, nested-quantifier, group count, alternation, depth).
  - Multi-dim arrays return `dialect.ErrUnsupportedFeature`. `SupportsIndexAnalysis()` returns `false` (Spark indexing is storage-layer-specific — Delta Z-order vs Iceberg sort vs plain Parquet — out of scope for v1).
- **`spark/provider.go`** — type provider mirroring `mysql/sqlite/duckdb` (caller-owned `*sql.DB`). `LoadTableSchema` runs `DESCRIBE TABLE`, validates table names (allowing dots for `catalog.schema.table`), parses `array<T>` and `struct<…>` types, skips trailing partition-info rows. Works with any `database/sql` driver such as `gohive` for Hive/Spark Thrift.
- **`testcases/*.go`** — Spark `WantSQL` entry added to every shared test case across basic/operator/string/regex/cast/array/timestamp/comprehension/json/parameterized — full coverage, no skip flags.
- **`testutil/`** — `SparkEnvFactory()` + `TestSparkSharedCases` / `TestSparkParameterizedSharedCases` runners.
- **`README.md`** — bump dialect count 5→6, add Spark badge, dialect comparison column, index-analysis row, import block.
- **`CLAUDE.md`** — Project Overview / Core Components / per-dialect provider examples / Project Structure tree all updated.

### Out of scope (follow-ups if users ask)

- Spark Connect Go client integration for live catalog introspection (currently use `*sql.DB` + `gohive`/JDBC bridge).
- Index advisor with Z-order/clustering hints — needs storage-layer detection.
- JSON-array comprehension across `from_json`-cast arrays without manual element-type annotation.

## Test plan

- [x] `golangci-lint run` — 0 issues
- [x] `go test -count=1 -short -race ./...` — all dialect packages green (`spark`, `pg` (unit only), `mysql`, `sqlite`, `duckdb`, `bigquery`, `testutil`, top-level)
- [x] `TestSparkSharedCases` / `TestSparkParameterizedSharedCases` — every case has a Spark `WantSQL` entry; all pass
- [ ] CI green
- [ ] Manual smoke test against a real Spark cluster (Databricks SQL warehouse / Spark Thrift) — defer to anyone who has one handy

🤖 Generated with [Claude Code](https://claude.com/claude-code)