### PR TITLE
chore: add three development skills (re-targeted from #119)

### DIFF
--- a/.claude/skills/add-cel-feature/SKILL.md
+++ b/.claude/skills/add-cel-feature/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: add-cel-feature
+description: Adds new CEL operator, function, macro, or comprehension support to cel2sql across all SQL dialects, touching cel2sql.go visit*, the dialect.Dialect interface, every dialect/<name>/dialect.go, and testcases/<category>_tests.go. Use when wiring a new CEL function (e.g., string.toLowerCase, timestamp.toISOString), a new comprehension form, a new operator overload, or extending the converter to recognise a CEL extension package.
+---
+
+# Add CEL Feature
+
+Adding a new CEL surface area (function, operator, macro, comprehension) is the second-most-common contribution shape after adding a dialect (5+ feature PRs in the recent history: string-extension functions, comprehensions, multi-dim arrays, regex, get/setDayOfWeek). The work is the same shape every time — this skill captures it.
+
+## Quick start
+
+1. **Classify the feature** — function call, operator, macro (like `has()`), or comprehension form (like `all`/`exists`/`filter`/`map`).
+2. **Identify the converter file** that owns the surface area — see [references/converter-file-map.md](references/converter-file-map.md).
+3. **Decide whether a new `dialect.Dialect` method is needed** — see "New method or inline?" below.
+4. **If a new method is needed**, walk [references/dialect-method-checklist.md](references/dialect-method-checklist.md) — the new method must land in `dialect/dialect.go` plus all six dialect packages.
+5. **Add a test case** to the appropriate `testcases/<category>_tests.go` with a `WantSQL` entry for every dialect (use the gen-script from `add-sql-dialect` if outputs diverge significantly).
+6. **Run** `python .claude/skills/add-sql-dialect/scripts/check_testcase_coverage.py <each-dialect>` to confirm coverage is still complete.
+
+## New method or inline?
+
+The `dialect.Dialect` interface is already large (~47 methods). Add a new method only when needed; otherwise inline the SQL in the visitor.
+
+| Situation | Verdict |
+|---|---|
+| The SQL is identical across all six dialects | Inline in the visitor (e.g., `con.str.WriteString("MOD(")` for `%`). |
+| Any dialect needs a different syntax | New `dialect.Dialect` method. |
+| A subset of dialects don't support the feature at all | New method + each unsupported dialect returns `dialect.ErrUnsupportedFeature`. |
+| The feature is JSON-related, regex-related, or array-related | Look for an existing `Write…` method first — JSON/array/regex method coverage is broad. |
+
+If you add a method, the compile-time `var _ dialect.Dialect = (*Dialect)(nil)` assertion at the top of every dialect file will catch missing implementations. The build won't pass until all six dialects are updated.
+
+## Where features live
+
+For example: adding `string.toLowerCase()`. CEL parses this as a method call on a string value. The visitor entry is `visitCall` in `cel2sql.go`. CEL's standard string functions are dispatched by overload ID — see how `startsWith`/`endsWith`/`contains` are wired and follow the same pattern. The output SQL (`LOWER(expr)`) is identical across all dialects, so this is a candidate for inline conversion (no new `Dialect` method).
+
+For another example: adding `timestamp.toUnixSeconds()`. The output diverges (`EXTRACT(EPOCH FROM e)::bigint` PG, `UNIX_TIMESTAMP(e)` MySQL, etc.) — so add a new `Dialect.WriteUnixSeconds(w, writeExpr)` method. `cel2sql.go` is generic; per-dialect SQL goes in `dialect/<name>/dialect.go`.
+
+For the file-by-file map, see [references/converter-file-map.md](references/converter-file-map.md).
+
+## CEL environment registration
+
+For a new function, the CEL environment must declare it before the converter can compile expressions that use it. Check if it's already registered in:
+
+- `testutil/env.go` `NewDefaultEnv` / `NewTimestampEnv` — for the test environments.
+- The user's CEL environment (out of scope for this skill).
+
+If you add a function only to the test environment, the user-facing API (the documentation) needs to mention the new function so consumers know to register it themselves.
+
+## Testcase coverage
+
+Add a representative test to `testcases/<category>_tests.go` (or the appropriate category file). The test must have a `WantSQL[dialect.<Name>]` entry for every dialect, or a `SkipDialect[dialect.<Name>]` reason for any that legitimately can't express the feature.
+
+If the SQL output diverges significantly across dialects, use the `gen_expected_sql.go.tmpl` template from the `add-sql-dialect` skill to generate the actual outputs in bulk:
+
+**Run** `cp .claude/skills/add-sql-dialect/templates/gen_expected_sql.go.tmpl testutil/gen_<dialect>_test.go` for each dialect, transcribe outputs, delete the generators.
+
+After the test case is in place, **run** the coverage check for every dialect:
+
+```
+for d in postgresql mysql sqlite duckdb bigquery spark; do
+  python .claude/skills/add-sql-dialect/scripts/check_testcase_coverage.py "$d"
+done
+```
+
+A new test case missing a single dialect's `WantSQL` entry silently skips for that dialect — easy regression to ship without this check.
+
+## Resources
+
+- [references/converter-file-map.md](references/converter-file-map.md) — which converter file owns which CEL surface area.
+- [references/dialect-method-checklist.md](references/dialect-method-checklist.md) — checklist when adding a method to the `Dialect` interface.
+- **Run** `python .claude/skills/add-sql-dialect/scripts/check_testcase_coverage.py <dialect>` — verifies test coverage; reuse the script across this skill and `add-sql-dialect`.

--- a/.claude/skills/add-cel-feature/references/converter-file-map.md
+++ b/.claude/skills/add-cel-feature/references/converter-file-map.md
@@ -1,0 +1,70 @@
+# Converter File Map
+
+Where each CEL surface area lives in the converter. Use this to find the visitor that needs updating when adding a feature.
+
+## Contents
+
+- Top-level dispatch
+- Operators and special-cased operators
+- Comprehensions
+- JSON / JSONB
+- Timestamps and durations
+- Index analysis
+- Where it doesn't go
+
+## Top-level dispatch
+
+| File | Owns |
+|---|---|
+| `cel2sql.go` | The `converter` struct, `Convert` / `ConvertParameterized` entry points, the `visit` dispatch (`visitCall`, `visitSelect`, `visitIdent`, `visitList`, `visitConst`, `visitStruct`, `visitComprehension`), parameter-placeholder writing, identifier/struct-field validation, recursion-depth and output-length guards. |
+
+`visitCall` is the dispatch hub for nearly every CEL function and operator. New function support starts here, almost always by adding a new branch to the overload-ID switch (search for `overloads.Add`, `overloads.Contains`, etc., to see existing wiring).
+
+## Operators and special-cased operators
+
+| File | Owns |
+|---|---|
+| `operators.go` | `standardSQLBinaryOperators` map (CEL operator → SQL token), reverse lookup, helper predicates like `isStringLiteral`, `isNullLiteral`, `isBoolLiteral`, `isListType`, `isNumericComparison`, `isFieldAccessExpression`. |
+| `cel2sql.go` `visitCallBinary` | Binary operator emission with special cases (`||` for string/list concat, `IS`/`IS NOT` for null/bool comparisons, JSON-text numeric coercion via `WriteCastToNumeric`, IN-list dispatch to `WriteArrayMembership` or `WriteJSONArrayMembership`). |
+
+Adding a new operator overload (e.g., timestamp + duration) usually requires updates here.
+
+## Comprehensions
+
+| File | Owns |
+|---|---|
+| `comprehensions.go` | The `ComprehensionInfo` struct, `identifyComprehension`, comprehension-shape predicates. |
+| `cel2sql.go` `visitComprehension`, `visitAllComprehension`, `visitExistsComprehension`, `visitExistsOneComprehension`, `visitFilterComprehension`, `visitMapComprehension`, `writeComprehensionSource` | Per-shape SQL emission. |
+
+The comprehension source is dispatched to either `dialect.WriteUnnest` (native arrays) or `dialect.WriteJSONArrayElements` (JSON arrays).
+
+## JSON / JSONB
+
+| File | Owns |
+|---|---|
+| `json.go` | JSON-path detection (`shouldUseJSONPath`, `hasJSONFieldInChain`), JSON-variable handling (`isJSONVariable` for `WithJSONVariables`), `has()` macro emission, JSON path construction (`buildJSONPath`, `buildJSONPathInternal`, `buildJSONPathForArray`), JSON field name escaping. |
+
+The detection chain is: schema-driven (via `isFieldJSON`) → JSON-variable (via `WithJSONVariables`) → fallback to chain-walk (`hasJSONFieldInChain`). Adding new JSON behaviour usually plugs into `shouldUseJSONPath` plus a new `dialect.Dialect` method.
+
+## Timestamps and durations
+
+| File | Owns |
+|---|---|
+| `timestamps.go` | Custom CEL types for `DATE` / `TIME` / `DATETIME` / `INTERVAL`, duration parsing, EXTRACT helpers, timestamp arithmetic dispatch. |
+
+Adding a new timestamp accessor (e.g., `getQuarter()`) goes here. Day-of-week conversion is handled per-dialect via `Dialect.WriteExtract` (CEL convention: Sunday=0).
+
+## Index analysis
+
+| File | Owns |
+|---|---|
+| `analysis.go` | `AnalyzeQuery` entry point; pattern detection (`PatternComparison`, `PatternJSONAccess`, `PatternRegexMatch`, `PatternArrayMembership`, `PatternArrayComprehension`, `PatternJSONArrayComprehension`); pattern → DDL delegation to `dialect.IndexAdvisor`. |
+
+Adding a new pattern type means: extend `analysis.go` to detect it, add a `PatternType` constant in `dialect/index_advisor.go`, then implement the new pattern in each dialect's `index_advisor.go`.
+
+## Where it doesn't go
+
+- Per-dialect SQL syntax → `dialect/<name>/dialect.go`. The converter is dialect-agnostic.
+- Reserved keywords / identifier rules → `dialect/<name>/validation.go`.
+- Regex pattern translation (RE2 → engine-native) → `dialect/<name>/regex.go`.
+- Type provider / database-introspection → `<name>/provider.go`.

--- a/.claude/skills/add-cel-feature/references/dialect-method-checklist.md
+++ b/.claude/skills/add-cel-feature/references/dialect-method-checklist.md
@@ -1,0 +1,93 @@
+# Dialect Method Checklist
+
+Steps when adding a new method to the `dialect.Dialect` interface. Skip the new-method route entirely if the SQL output is identical across all six dialects (just inline in the converter).
+
+## Contents
+
+- Step-by-step
+- Compile-time safety net
+- Naming conventions
+- Error returns
+- Worked example: WriteUnixSeconds
+
+## Step-by-step
+
+1. **Declare the method on the interface** in `dialect/dialect.go`. Group it with related methods (Literals / Operators / Type Casting / Arrays / JSON / Timestamps / String Functions / Comprehensions / Struct / Validation / Regex / Capabilities). Add a one-line doc comment naming the canonical PostgreSQL form ("For PostgreSQL: …") to anchor reviewers.
+2. **Implement in all six dialect packages.** The canonical six are:
+   - `dialect/postgres/dialect.go`
+   - `dialect/mysql/dialect.go`
+   - `dialect/sqlite/dialect.go`
+   - `dialect/duckdb/dialect.go`
+   - `dialect/bigquery/dialect.go`
+   - `dialect/spark/dialect.go`
+3. **Verify the compile-time assertion fires.** Each dialect file ends with `var _ dialect.Dialect = (*Dialect)(nil)` — running `go build ./...` will fail if any dialect is missing the new method.
+4. **Wire the method into the converter** in `cel2sql.go` (or whichever visitor file owns the surface area — see the converter-file-map reference). The converter calls `con.dialect.<NewMethod>(...)`.
+5. **Add a representative test case** to `testcases/<category>_tests.go`. Set `WantSQL[dialect.<Name>]` for every dialect or document a `SkipDialect[dialect.<Name>]` reason.
+6. **Run the testcase coverage check** for every dialect:
+   ```
+   for d in postgresql mysql sqlite duckdb bigquery spark; do
+     python .claude/skills/add-sql-dialect/scripts/check_testcase_coverage.py "$d"
+   done
+   ```
+
+## Compile-time safety net
+
+The `var _ dialect.Dialect = (*Dialect)(nil)` line at the top of every dialect file is critical. It's the only mechanism that guarantees all dialects implement every method. If you add a new dialect, add this line first.
+
+## Naming conventions
+
+Methods on the `Dialect` interface that emit SQL fragments are prefixed `Write…`. They take a `*strings.Builder` (the converter's output buffer) plus callbacks `func() error` for any sub-expressions the dialect needs to interleave. They return `error` so dialects that don't support a feature can return `dialect.ErrUnsupportedFeature`.
+
+Capability check methods are `Supports…` and return `bool`.
+
+## Error returns
+
+`dialect.ErrUnsupportedFeature` is the sentinel for "this dialect cannot express this CEL construct." Wrap it with `fmt.Errorf("%w: <reason>", dialect.ErrUnsupportedFeature, ...)` so callers can `errors.Is()` it.
+
+Examples already in the codebase:
+- `dialect/sqlite/dialect.go` `WriteRegexMatch` returns `ErrUnsupportedFeature` (SQLite has no native regex).
+- `dialect/spark/dialect.go` `WriteArrayLength` returns `ErrUnsupportedFeature` for `dimension > 1` (Spark doesn't support multi-dim arrays).
+
+## Worked example: WriteUnixSeconds
+
+Suppose CEL's `int(timestamp)` should emit a per-dialect Unix-seconds expression.
+
+1. **Interface** (`dialect/dialect.go`):
+   ```go
+   // WriteEpochExtract writes extraction of epoch from a timestamp.
+   // For PostgreSQL: EXTRACT(EPOCH FROM expr)::bigint.
+   WriteEpochExtract(w *strings.Builder, writeExpr func() error) error
+   ```
+2. **PostgreSQL** (`dialect/postgres/dialect.go`):
+   ```go
+   func (d *Dialect) WriteEpochExtract(w *strings.Builder, writeExpr func() error) error {
+       w.WriteString("EXTRACT(EPOCH FROM ")
+       if err := writeExpr(); err != nil { return err }
+       w.WriteString(")::bigint")
+       return nil
+   }
+   ```
+3. **MySQL**: `UNIX_TIMESTAMP(<expr>)`.
+4. **SQLite**: `CAST(strftime('%s', <expr>) AS INTEGER)`.
+5. **DuckDB**: `EXTRACT(EPOCH FROM <expr>)::BIGINT`.
+6. **BigQuery**: `UNIX_SECONDS(<expr>)`.
+7. **Spark**: `UNIX_TIMESTAMP(<expr>)`.
+
+(All six already implement this method — it's a real example from the codebase.)
+
+8. **Test case** in `testcases/cast_tests.go`:
+   ```go
+   {
+       Name:     "cast_int_epoch",
+       CELExpr:  `int(created_at)`,
+       Category: CategoryCast,
+       WantSQL: map[dialect.Name]string{
+           dialect.PostgreSQL: "EXTRACT(EPOCH FROM created_at)::bigint",
+           dialect.MySQL:      "UNIX_TIMESTAMP(created_at)",
+           dialect.SQLite:     "CAST(strftime('%s', created_at) AS INTEGER)",
+           dialect.DuckDB:     "EXTRACT(EPOCH FROM created_at)::BIGINT",
+           dialect.BigQuery:   "UNIX_SECONDS(created_at)",
+           dialect.Spark:      "UNIX_TIMESTAMP(created_at)",
+       },
+   },
+   ```

--- a/.claude/skills/add-sql-dialect/SKILL.md
+++ b/.claude/skills/add-sql-dialect/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: add-sql-dialect
+description: Adds a new SQL dialect to cel2sql by registering its name, implementing the Dialect interface in dialect/<name>/, adding a sibling type provider in <name>/, populating shared test cases in testcases/, and refreshing README.md and CLAUDE.md. Use when adding any new database backend (Trino, Snowflake, ClickHouse, MS SQL, Athena, Oracle) or porting cel2sql to another analytics engine.
+---
+
+# Add SQL Dialect
+
+Adding a SQL dialect is the largest contribution shape in this repo (~1000-line PR, ~25 file touches in lockstep). The pattern is well-established — six dialects already follow it. This skill captures the procedure so the engineer can follow the template instead of reverse-engineering the layout from existing dialects.
+
+## Quick start
+
+1. **Pick the closest analogue** by syntax family — see "Picking the analogue" below.
+2. **Register the name** — add `<Name> Name = "<name>"` to the constants block in `dialect/dialect.go`.
+3. **Implement the four files under `dialect/<name>/`**: `dialect.go` (the SQL emitter), `regex.go` (RE2 → engine-native conversion + ReDoS validators), `validation.go` (reserved keywords + identifier regex), and optionally `index_advisor.go`.
+4. **Implement the type provider under `<name>/`**: `provider.go` + `provider_test.go`. Mirror `mysql/provider.go` for caller-owned `*sql.DB`, or `pg/provider.go` for owned-pool.
+5. **Wire the test runner**: add `<Name>EnvFactory()` to `testutil/env.go`, add the dialect to `DialectEnvFactory()`'s switch, create `testutil/runner_<name>_test.go`.
+6. **Populate shared test cases** — see "Testcase coverage" below.
+7. **Refresh docs** — see [references/touchpoints.md](references/touchpoints.md) for the exhaustive file list.
+8. **Run** `python .claude/skills/skill-authoring/scripts/lint_skill.py .claude/skills/<name>` if you also added a new skill alongside.
+
+## Picking the analogue
+
+Decide by which existing dialect's syntax shape your target most resembles:
+
+| Question | Operator-style → use DuckDB | Function-style → use BigQuery |
+|---|---|---|
+| Regex match | `target ~ 'p'` (PG, DuckDB) | `REGEXP_CONTAINS(target, 'p')` (BQ); `RLIKE` (Spark) |
+| JSON access | `b->>'f'` (PG, DuckDB) | `JSON_VALUE(b, '$.f')` (BQ); `get_json_object()` (Spark) |
+| Array literal | `ARRAY[…]` (PG); `[…]` (DuckDB, BQ) | `array(…)` (Spark) |
+| Array index | 1-indexed (PG, DuckDB) | 0-indexed (BQ via OFFSET, Spark direct) |
+| Param placeholder | `$N` (PG, DuckDB) | `?` (MySQL, SQLite, Spark) or `@pN` (BQ) |
+| Cast to numeric | `::numeric` postfix (PG, DuckDB) | ` + 0` arithmetic coercion (MySQL, SQLite, Spark) |
+
+For the half-dozen most-divergent methods at a glance, see [references/dialect-method-matrix.md](references/dialect-method-matrix.md). When in doubt, copy DuckDB and patch — its layout is the cleanest.
+
+## Critical surface to map
+
+These methods on `dialect.Dialect` are where dialects diverge most. Plan how to implement them before writing any code:
+
+- `WriteRegexMatch` — operator vs function call
+- `WriteJSONFieldAccess` — operator (`->>`) vs function wrapper (`JSON_VALUE`, `get_json_object`); whether intermediate vs final access uses different forms
+- `WriteArrayLiteralOpen/Close` — `ARRAY[`, `[`, `array(`
+- `WriteListIndex` / `WriteListIndexConst` — 0-indexed vs 1-indexed; bare `[i]` vs `OFFSET(i)` vs `+ 1`
+- `WriteParamPlaceholder` — `$N`, `?`, `@pN`
+- `WriteExtract` for DOW — Sunday-1 (BQ, Spark) vs Sunday-0 (PG/DuckDB convention) — adjust by `+ 6) % 7` or `- 1`
+- `WriteCastToNumeric` — postfix `::TYPE` vs arithmetic coercion `+ 0`
+- `WriteJSONArrayElements` — must be a **set-returning expression** (used in `FROM <here> AS iter`); use the engine's `EXPLODE`/`UNNEST`/`json_each`/`from_json` form
+- `WriteJSONArrayMembership` — must produce a valid RHS for `lhs = ` (subquery form, like SQLite's `(SELECT value FROM json_each(...))`)
+
+## Testcase coverage
+
+The shared test runner (`testutil/RunAllConvertTests`) iterates `testcases/*.go` and reads the new dialect's `WantSQL[dialect.<Name>]` entry. Tests with no entry **and** no `SkipDialect` reason are silently skipped, which masks regressions.
+
+To populate `WantSQL` efficiently, generate the actual output once and paste it back in:
+
+1. **Run** `cp .claude/skills/add-sql-dialect/templates/gen_expected_sql.go.tmpl testutil/gen_<name>_test.go` and substitute `{{DIALECT}}` (lowercase) and `{{Dialect}}` (PascalCase) and `{{DialectFactory}}` in the file.
+2. **Run** `go test -tags=<name>gen -v -run TestGen<Dialect>Expected ./testutil/`.
+3. Paste outputs into the corresponding `testcases/*.go` `WantSQL` maps.
+4. Delete `testutil/gen_<name>_test.go`.
+5. **Run** `python .claude/skills/add-sql-dialect/scripts/check_testcase_coverage.py <name>` from the repo root to verify every test case has either a `WantSQL[dialect.<Name>]` entry or a `SkipDialect[dialect.<Name>]` reason. The script exits non-zero if anything is missing.
+
+## Optional: IndexAdvisor
+
+Implement `dialect/<name>/index_advisor.go` only if the engine has user-controllable indexes (BTREE, GIN, ART, CLUSTERING). Skip for storage-layer-driven engines like Spark (Delta Z-order, Iceberg sort) — set `SupportsIndexAnalysis()` to `false`.
+
+## Doc refresh
+
+When the implementation is green, refresh:
+
+- `README.md`: bump dialect count, add badge, add column to the comparison table, add row to the index-analysis table, add to the import block.
+- `CLAUDE.md`: Project Overview count, new entry in Core Components, new entry in Project Structure tree.
+
+The full file-by-file checklist is in [references/touchpoints.md](references/touchpoints.md).
+
+## Resources
+
+- [references/dialect-method-matrix.md](references/dialect-method-matrix.md) — the most-divergent `Dialect` methods across the existing six dialects, side by side.
+- [references/touchpoints.md](references/touchpoints.md) — exhaustive file-by-file checklist for a new dialect.
+- [templates/gen_expected_sql.go.tmpl](templates/gen_expected_sql.go.tmpl) — build-tagged Go test template that prints actual SQL output for every shared test case.
+- **Run** `python scripts/check_testcase_coverage.py <name>` — verifies `WantSQL`/`SkipDialect` coverage for the dialect across all testcases files.

--- a/.claude/skills/add-sql-dialect/references/dialect-method-matrix.md
+++ b/.claude/skills/add-sql-dialect/references/dialect-method-matrix.md
@@ -1,0 +1,104 @@
+# Dialect Method Matrix
+
+## Contents
+
+- Literals
+- Operators
+- Type casting
+- Arrays
+- JSON
+- Timestamps
+- String functions
+- Comprehensions
+- Validation + capabilities
+- How to use this matrix
+
+## How to use this matrix
+
+When implementing a new dialect, scan each row to find which existing dialect's form your target engine matches, then copy that implementation. The full method list (~47 methods) lives in `dialect/dialect.go`; only the most-divergent ones are tabled here.
+
+## Literals
+
+| Method | PostgreSQL | DuckDB | MySQL | SQLite | BigQuery | Spark |
+|---|---|---|---|---|---|---|
+| `WriteStringLiteral` | `'v'` (`''` esc) | `'v'` (`''` esc) | `'v'` (`''` esc) | `'v'` (`''` esc) | `'v'` (`\'` esc) | `'v'` (`''` esc) |
+| `WriteBytesLiteral` | `'\xHH…'` | `'\xhh…'` | `X'HH…'` | `X'HH…'` | `b"\OOO…"` (octal) | `X'HH…'` |
+| `WriteParamPlaceholder` | `$1, $2` | `$1, $2` | `?, ?` | `?, ?` | `@p1, @p2` | `?, ?` |
+
+## Operators
+
+| Method | PostgreSQL | DuckDB | MySQL | SQLite | BigQuery | Spark |
+|---|---|---|---|---|---|---|
+| `WriteStringConcat` | `lhs \|\| rhs` | `lhs \|\| rhs` | `CONCAT(lhs, rhs)` | `lhs \|\| rhs` | `lhs \|\| rhs` | `concat(lhs, rhs)` |
+| `WriteRegexMatch` | `t ~ 'p'` / `~* 'p'` | `t ~ 'p'` / `~* 'p'` | `t REGEXP 'p'` | unsupported | `REGEXP_CONTAINS(t, 'p')` | `t RLIKE 'p'` |
+| `WriteLikeEscape` | `ESCAPE E'\\\\'` | `ESCAPE '\\\\'` | `ESCAPE '\\\\'` | `ESCAPE '\\'` | (no-op; default backslash) | `ESCAPE '\\\\'` |
+| `WriteArrayMembership` | `e = ANY(a)` | `e = ANY(a)` | `JSON_CONTAINS(a, CAST(e AS JSON))` | `e IN (SELECT value FROM json_each(a))` | `e IN UNNEST(a)` | `array_contains(a, e)` |
+
+## Type casting
+
+| Method | PostgreSQL | DuckDB | MySQL | SQLite | BigQuery | Spark |
+|---|---|---|---|---|---|---|
+| `WriteCastToNumeric` | `::numeric` | `::DOUBLE` | ` + 0` | ` + 0` | `::FLOAT64` | ` + 0` |
+| `WriteTypeName` (int) | `BIGINT` | `BIGINT` | `SIGNED` | `INTEGER` | `INT64` | `BIGINT` |
+| `WriteTypeName` (string) | `TEXT` | `VARCHAR` | `CHAR` | `TEXT` | `STRING` | `STRING` |
+| `WriteTypeName` (bool) | `BOOLEAN` | `BOOLEAN` | `UNSIGNED` | `INTEGER` | `BOOL` | `BOOLEAN` |
+| `WriteTypeName` (bytes) | `BYTEA` | `BLOB` | `BINARY` | `BLOB` | `BYTES` | `BINARY` |
+| `WriteTimestampCast` | `CAST(e AS TIMESTAMP WITH TIME ZONE)` | `CAST(e AS TIMESTAMPTZ)` | `CAST(e AS DATETIME)` | `datetime(e)` | `CAST(e AS TIMESTAMP)` | `CAST(e AS TIMESTAMP)` |
+| `WriteEpochExtract` | `EXTRACT(EPOCH FROM e)::bigint` | `EXTRACT(EPOCH FROM e)::BIGINT` | `UNIX_TIMESTAMP(e)` | `CAST(strftime('%s', e) AS INTEGER)` | `UNIX_SECONDS(e)` | `UNIX_TIMESTAMP(e)` |
+
+## Arrays
+
+| Method | PostgreSQL | DuckDB | BigQuery | Spark | MySQL/SQLite |
+|---|---|---|---|---|---|
+| `WriteArrayLiteralOpen` | `ARRAY[` | `[` | `[` | `array(` | n/a (JSON arrays) |
+| `WriteArrayLiteralClose` | `]` | `]` | `]` | `)` | n/a |
+| `WriteArrayLength` | `COALESCE(ARRAY_LENGTH(e, dim), 0)` | `COALESCE(array_length(e), 0)` | `ARRAY_LENGTH(e)` | `COALESCE(size(e), 0)` (errors on dim>1) | varies |
+| `WriteListIndex` | `a[i + 1]` | `a[i + 1]` | `a[OFFSET(i)]` | `a[i]` | varies |
+| `WriteListIndexConst` | `a[i+1]` | `a[i+1]` | `a[OFFSET(i)]` | `a[i]` | varies |
+| `WriteEmptyTypedArray` | `ARRAY[]::T[]` | `[]::T[]` | `ARRAY<T>[]` | `CAST(array() AS ARRAY<T>)` | `JSON_ARRAY()` (MySQL); `json_array()` (SQLite) |
+
+## JSON
+
+| Method | PostgreSQL | DuckDB | MySQL | SQLite | BigQuery | Spark |
+|---|---|---|---|---|---|---|
+| `WriteJSONFieldAccess` (final) | `b->>'f'` | `b->>'f'` | `b->>'$.f'` | `json_extract(b, '$.f')` | `JSON_VALUE(b, '$.f')` | `get_json_object(b, '$.f')` |
+| `WriteJSONFieldAccess` (intermediate) | `b->'f'` | `b->'f'` | `b->'$.f'` | `json_extract(b, '$.f')` | `JSON_QUERY(b, '$.f')` | `get_json_object(b, '$.f')` |
+| `WriteJSONExistence` | `b ? 'f'` | `json_exists(b, '$.f')` | `JSON_CONTAINS_PATH(b, 'one', '$.f')` | `json_type(b, '$.f') IS NOT NULL` | `JSON_VALUE(b, '$.f') IS NOT NULL` | `get_json_object(b, '$.f') IS NOT NULL` |
+| `WriteJSONArrayElements` | `jsonb_array_elements(e)` (must be set-returning!) | `json_each(e)` | varies | `json_each(e)` | `UNNEST(JSON_QUERY_ARRAY(e))` | `EXPLODE(from_json(e, 'ARRAY<STRING>'))` |
+| `WriteJSONArrayMembership` (RHS of `lhs = `) | `ANY(ARRAY(SELECT jsonb_func(e)))` | `(SELECT value FROM json_each(e))` | `JSON_CONTAINS(e, CAST(? AS JSON))` | `(SELECT value FROM json_each(e))` | `UNNEST(JSON_VALUE_ARRAY(e))` | `(SELECT col FROM (SELECT EXPLODE(from_json(e, 'ARRAY<STRING>')) AS col) t)` |
+
+## Timestamps
+
+| Method | PostgreSQL | DuckDB | MySQL | SQLite | BigQuery | Spark |
+|---|---|---|---|---|---|---|
+| `WriteDuration` | `INTERVAL N UNIT` | `INTERVAL N UNIT` | `INTERVAL N UNIT` | `'+N units'` | `INTERVAL N UNIT` | `INTERVAL N UNIT` |
+| `WriteTimestampArithmetic` | `ts +/- iv` | `ts +/- iv` | `ts +/- iv` | `datetime(ts, '...')` | `TIMESTAMP_ADD/SUB(ts, iv)` | `ts +/- iv` |
+| `WriteExtract` (DOW) | `EXTRACT(DOW FROM e)` | `(EXTRACT(DOW FROM e) + 6) % 7` | varies | `strftime('%w', e)` | `EXTRACT(DAYOFWEEK FROM e) - 1` | `(dayofweek(e) - 1)` |
+
+DOW convention: CEL wants `Sunday=0..Saturday=6`. PostgreSQL emits Sunday=0 already; DuckDB returns Monday=1..Sunday=0 (off by one in the wrong direction, hence the `+6) % 7` adjustment); BigQuery `DAYOFWEEK` returns Sunday=1..Saturday=7 (subtract 1); Spark `dayofweek()` matches BigQuery.
+
+## String functions
+
+| Method | PostgreSQL | DuckDB | MySQL | SQLite | BigQuery | Spark |
+|---|---|---|---|---|---|---|
+| `WriteContains` | `POSITION(n IN h) > 0` | `CONTAINS(h, n)` | `LOCATE(n, h) > 0` | `INSTR(h, n) > 0` | `STRPOS(h, n) > 0` | `LOCATE(n, h) > 0` |
+| `WriteSplit` | `STRING_TO_ARRAY(s, d)` | `STRING_SPLIT(s, d)` | varies (JSON arrays) | varies | `SPLIT(s, d)` | `split(s, d)` |
+| `WriteJoin` | `ARRAY_TO_STRING(a, d, '')` | `ARRAY_TO_STRING(a, d)` | varies | varies | `ARRAY_TO_STRING(a, d)` | `array_join(a, d)` |
+
+## Comprehensions
+
+| Method | PostgreSQL | DuckDB | BigQuery | Spark | SQLite |
+|---|---|---|---|---|---|
+| `WriteUnnest` | `UNNEST(s)` | `UNNEST(s)` | `UNNEST(s)` | `EXPLODE(s)` | `json_each(s)` |
+| `WriteArraySubqueryOpen` | `ARRAY(SELECT ` | `ARRAY(SELECT ` | `ARRAY(SELECT ` | `(SELECT collect_list(` | `(SELECT json_group_array(` |
+| `WriteArraySubqueryExprClose` | `` | `` | `` | `)` | `)` |
+
+## Validation + capabilities
+
+| Method | PostgreSQL | DuckDB | MySQL | SQLite | BigQuery | Spark |
+|---|---|---|---|---|---|---|
+| `MaxIdentifierLength` | 63 | 0 (unlimited) | 64 | 0 (unlimited) | 300 | 128 |
+| `SupportsRegex` | true | true | true | **false** | true | true |
+| `SupportsNativeArrays` | true | true | false | false | true | true |
+| `SupportsJSONB` | true | false | false | false | false | false |
+| `SupportsIndexAnalysis` | true | true | true | true | true | **false** |

--- a/.claude/skills/add-sql-dialect/references/touchpoints.md
+++ b/.claude/skills/add-sql-dialect/references/touchpoints.md
@@ -1,0 +1,153 @@
+# Touchpoints for Adding a Dialect
+
+Exhaustive file-by-file checklist. Paths are relative to the repo root. Replace `<name>` with the lowercase dialect name (e.g. `spark`) and `<Name>` with the PascalCase form (e.g. `Spark`).
+
+## Contents
+
+- Required files
+- Optional files
+- Files to modify
+- Verification checklist
+
+## Required files
+
+### 1. Register the name
+
+`dialect/dialect.go` — add a constant to the `Name` block:
+
+```go
+const (
+    PostgreSQL Name = "postgresql"
+    MySQL      Name = "mysql"
+    // …
+    <Name>     Name = "<name>"
+)
+```
+
+### 2. SQL emitter
+
+`dialect/<name>/dialect.go` — implements the full `dialect.Dialect` interface (~47 methods). Pattern:
+
+```go
+package <name>
+
+type Dialect struct{}
+
+func New() *Dialect { return &Dialect{} }
+
+func init() {
+    dialect.Register(dialect.<Name>, func() dialect.Dialect { return New() })
+}
+
+var _ dialect.Dialect = (*Dialect)(nil)
+
+func (d *Dialect) Name() dialect.Name { return dialect.<Name> }
+// … all other methods
+```
+
+The compile-time `var _ dialect.Dialect = (*Dialect)(nil)` line catches any missing methods. The `init()` registration makes the dialect findable via `dialect.Get(dialect.<Name>)`.
+
+### 3. Regex conversion
+
+`dialect/<name>/regex.go` — exports `convertRE2To<Name>(pattern string) (converted string, caseInsensitive bool, err error)`. Reuse the ReDoS validator pattern from `dialect/duckdb/regex.go` (length cap 500, no nested quantifiers, ≤20 capture groups, max nesting depth 10, no quantified alternation).
+
+If the engine's regex flavor is RE2-compatible (Spark's Java regex, BigQuery's RE2): pass through unchanged after validation.
+If POSIX (PostgreSQL): translate `\d` → `[[:digit:]]`, `\w` → `[[:alnum:]_]`, `\s` → `[[:space:]]`, `\b` → `\y`.
+If unsupported: return `dialect.ErrUnsupportedFeature` and set `SupportsRegex()` to `false`.
+
+### 4. Validation
+
+`dialect/<name>/validation.go` — exports `validateFieldName(name string) error` and the `reservedSQLKeywords map[string]bool`. Field-name regex is typically `^[a-zA-Z_][a-zA-Z0-9_]*$`.
+
+### 5. Type provider
+
+`<name>/provider.go` — implements `types.Provider` for CEL. Mirror one of:
+
+- `mysql/provider.go` for caller-owned `*sql.DB` (most common — works with MySQL, SQLite, DuckDB, Spark).
+- `pg/provider.go` for owned `pgxpool.Pool` (PostgreSQL-specific connection-string form).
+- `bigquery/provider.go` for non-`database/sql` clients.
+
+Required: `NewSchema`, `NewTypeProvider(map[string]Schema)`, `NewTypeProviderWithConnection(ctx, db)` (or `WithClient`), `LoadTableSchema(ctx, name)`, `Close()`, plus the `types.Provider` methods (`FindStructType`, `FindStructFieldNames`, `FindStructFieldType`, etc.).
+
+`LoadTableSchema` strategy:
+- `information_schema.columns` (MySQL, DuckDB) — preferred, supports parameterized table names.
+- `PRAGMA table_info(<name>)` (SQLite) — table name must be regex-validated, `// #nosec G202` suppression required.
+- `DESCRIBE TABLE <name>` (Spark) — same as PRAGMA: regex-validate, `#nosec G202`.
+- Vendor client API (BigQuery via `Table.Metadata`).
+
+### 6. Provider unit tests
+
+`<name>/provider_test.go` — cover type mapping, schema lookup (`FindStructType`, `FindStructFieldType`), name validation rejection cases (SQL injection inputs).
+
+### 7. Test environment factory
+
+`testutil/env.go` — add `<Name>EnvFactory()` and a case in `DialectEnvFactory()`. Pattern:
+
+```go
+func <Name>EnvFactory() func(envSetup string) (*EnvResult, error) {
+    return func(envSetup string) (*EnvResult, error) {
+        switch envSetup {
+        case testcases.EnvDefault:    /* … */
+        case testcases.EnvWithTimestamp: /* … */
+        case testcases.EnvWithJSON:   /* … */
+        }
+        result.Opts = append(result.Opts, cel2sql.WithDialect(<name>Dialect.New()))
+        return result, nil
+    }
+}
+```
+
+### 8. Shared test runner
+
+`testutil/runner_<name>_test.go` — 17-line file:
+
+```go
+func Test<Name>SharedCases(t *testing.T) {
+    testutil.RunAllConvertTests(t, dialect.<Name>, testutil.<Name>EnvFactory())
+}
+func Test<Name>ParameterizedSharedCases(t *testing.T) {
+    testutil.RunAllParameterizedTests(t, dialect.<Name>, testutil.<Name>EnvFactory())
+}
+```
+
+### 9. Shared test cases
+
+`testcases/*.go` — for **every** test case across `basic_tests.go`, `operator_tests.go`, `string_tests.go`, `regex_tests.go`, `cast_tests.go`, `array_tests.go`, `timestamp_tests.go`, `comprehension_tests.go`, `json_tests.go`, `parameterized_tests.go`: add a `dialect.<Name>` entry to `WantSQL` (and `WantParams` for parameterized cases). Where the dialect cannot express a case, add `SkipDialect[dialect.<Name>] = "<reason>"`.
+
+Use the `gen_expected_sql.go.tmpl` template to generate actual outputs in bulk.
+
+## Optional files
+
+### Index advisor
+
+`dialect/<name>/index_advisor.go` — implements the `IndexAdvisor` interface. Skip and return `false` from `SupportsIndexAnalysis()` if the engine has no user-controllable indexes (Spark on Delta, Iceberg, plain Parquet).
+
+## Files to modify
+
+### `README.md`
+
+- Title and intro: "N SQL dialects" → "N+1 SQL dialects".
+- Badges row: add a badge for the new engine.
+- Feature list bullet near the top: bump count.
+- "Multi-Dialect Support" intro: bump count + add to import list + add `WithDialect()` example.
+- Dialect comparison table (around the "Dialect Comparison" heading): add a new column.
+- Per-dialect type providers import block: add the import line.
+- Per-dialect index types table (under "Query Analysis"): add a new column.
+
+### `CLAUDE.md`
+
+- Project Overview line: "supports six SQL dialects" → "seven", add the new dialect name.
+- Core Components numbered list: add an entry for `<name>/provider.go`.
+- Per-dialect type providers section: add the new dialect to the connection-handling list.
+- Project Structure tree: add `<name>/` and `dialect/<name>/`.
+- Testing Guidelines: add `<name>.NewTypeProvider()` to the per-dialect provider list.
+
+## Verification checklist
+
+1. `make fmt && make build && make lint` clean.
+2. `go test -count=1 ./dialect/<name>/... ./<name>/...` passes.
+3. `go test -count=1 -run Test<Name>SharedCases ./testutil/` passes.
+4. `python .claude/skills/add-sql-dialect/scripts/check_testcase_coverage.py <name>` reports full coverage.
+5. `go test -count=1 -short -race ./...` — no regressions in existing dialects.
+6. `gosec ./<name>/... ./dialect/<name>/...` — 0 issues (note any `#nosec` annotations).
+7. PR description lists the new dialect and the index-analysis stance (supported / out-of-scope).

--- a/.claude/skills/add-sql-dialect/scripts/check_testcase_coverage.py
+++ b/.claude/skills/add-sql-dialect/scripts/check_testcase_coverage.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Verify that a dialect has WantSQL or SkipDialect coverage for every shared test case.
+
+Usage: python check_testcase_coverage.py <dialect-name>
+
+Where <dialect-name> is the lowercase name registered in dialect/dialect.go
+(postgresql, mysql, sqlite, duckdb, bigquery, spark, ...).
+
+Scans testcases/*.go for ConvertTestCase / ParameterizedTestCase blocks.
+For each block, verifies that either:
+  - WantSQL[dialect.<Name>] is present, OR
+  - WantErr[dialect.<Name>] is true, OR
+  - SkipDialect[dialect.<Name>] has a reason string.
+
+Run from the repo root. Exits 0 if coverage is complete, 1 otherwise.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT_MARKERS = ("go.mod", "testcases")
+
+
+def find_repo_root() -> Path:
+    cur = Path.cwd().resolve()
+    for d in [cur, *cur.parents]:
+        if all((d / m).exists() for m in REPO_ROOT_MARKERS):
+            return d
+    raise SystemExit("error: run from cel2sql repo root (go.mod and testcases/ must be siblings)")
+
+
+CASE_RE = re.compile(r"^\s*\{\s*$", re.M)
+
+
+def find_blocks(text: str) -> list[tuple[int, int, str]]:
+    """Yield every `{ ... }` block in the file.
+
+    Walks the source character by character, skipping string and comment
+    contents, and emits one region per balanced brace pair. The caller
+    filters down to actual test case literals via `is_test_case()`.
+    """
+    out: list[tuple[int, int, str]] = []
+    in_str = False
+    str_q = ""
+    in_comment = False
+    line_comment = False
+    starts: list[int] = []  # stack of open-brace positions
+
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+
+        if line_comment:
+            if ch == "\n":
+                line_comment = False
+            i += 1
+            continue
+        if in_comment:
+            if ch == "*" and nxt == "/":
+                in_comment = False
+                i += 2
+                continue
+            i += 1
+            continue
+        if in_str:
+            if ch == "\\" and str_q != "`":
+                i += 2
+                continue
+            if ch == str_q:
+                in_str = False
+                str_q = ""
+            i += 1
+            continue
+
+        if ch == "/" and nxt == "/":
+            line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            in_comment = True
+            i += 2
+            continue
+        if ch in ('"', "'", "`"):
+            in_str = True
+            str_q = ch
+            i += 1
+            continue
+
+        if ch == "{":
+            starts.append(i)
+        elif ch == "}":
+            if starts:
+                start = starts.pop()
+                out.append((start, i + 1, text[start : i + 1]))
+        i += 1
+    return out
+
+
+def has_dialect_entry(block: str, dialect: str) -> bool:
+    """Return True if block contains any of:
+      WantSQL[ ... dialect.<Name> ... ]
+      WantErr[ ... dialect.<Name> ... ]
+      SkipDialect[ ... dialect.<Name> ... ]
+    The map literals span lines, so we look for `dialect.<Name>:` anywhere
+    inside one of those map blocks. We also accept the bare token `dialect.<Name>`
+    as a conservative match.
+    """
+    pascal = dialect.capitalize()
+    if dialect == "postgresql":
+        pascal = "PostgreSQL"
+    elif dialect == "mysql":
+        pascal = "MySQL"
+    elif dialect == "sqlite":
+        pascal = "SQLite"
+    elif dialect == "duckdb":
+        pascal = "DuckDB"
+    elif dialect == "bigquery":
+        pascal = "BigQuery"
+    elif dialect == "spark":
+        pascal = "Spark"
+
+    token = re.compile(rf"\bdialect\.{pascal}\b")
+    return bool(token.search(block))
+
+
+def case_name(block: str) -> str:
+    m = re.search(r'Name:\s*"([^"]+)"', block)
+    return m.group(1) if m else "<anonymous>"
+
+
+NAME_FIELD_RE = re.compile(r'\bName:\s*"')
+
+
+def is_test_case(block: str) -> bool:
+    """Filter to only individual ConvertTestCase / ParameterizedTestCase blocks.
+
+    Heuristic: exactly one `Name: "…"` field (so we exclude the enclosing
+    slice literal and function body, which contain many) and at least one of
+    WantSQL / WantErr / WantParams / SkipDialect (so we exclude unrelated
+    struct literals like fixture FieldSchemas).
+    """
+    if len(NAME_FIELD_RE.findall(block)) != 1:
+        return False
+    return bool(re.search(r"\b(WantSQL|WantErr|WantParams|SkipDialect)\b", block))
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    dialect = sys.argv[1].strip().lower()
+    if not re.match(r"^[a-z][a-z0-9_]*$", dialect):
+        print(f"error: invalid dialect name {dialect!r}", file=sys.stderr)
+        sys.exit(2)
+
+    root = find_repo_root()
+    testcases_dir = root / "testcases"
+
+    missing: list[tuple[str, str]] = []
+    total = 0
+
+    for path in sorted(testcases_dir.glob("*_tests.go")):
+        text = path.read_text(encoding="utf-8")
+        for _, _, block in find_blocks(text):
+            if not is_test_case(block):
+                continue
+            total += 1
+            if not has_dialect_entry(block, dialect):
+                missing.append((path.name, case_name(block)))
+
+    if missing:
+        print(f"MISSING coverage for dialect.{dialect} in {len(missing)} of {total} test case(s):")
+        for fname, name in missing:
+            print(f"  {fname}: {name}")
+        sys.exit(1)
+
+    print(f"OK: dialect.{dialect} has coverage in all {total} shared test case(s).")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/add-sql-dialect/templates/gen_expected_sql.go.tmpl
+++ b/.claude/skills/add-sql-dialect/templates/gen_expected_sql.go.tmpl
@@ -1,0 +1,83 @@
+// Build-tag-gated generator that prints actual SQL output for every shared test
+// case under the {{DIALECT}} dialect. Copy this file to testutil/gen_{{DIALECT}}_test.go,
+// run `go test -tags={{DIALECT}}gen -v -run TestGen{{Dialect}}Expected ./testutil/`,
+// transcribe the output into testcases/*.go WantSQL maps, then DELETE this file.
+//
+// Replacements before use:
+//   {{DIALECT}}  → lowercase dialect name (e.g. "spark")
+//   {{Dialect}}  → PascalCase dialect name (e.g. "Spark")
+//   The factory call below assumes testutil.{{Dialect}}EnvFactory() exists; add
+//   it to testutil/env.go before running.
+
+//go:build {{DIALECT}}gen
+
+package testutil_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spandigital/cel2sql/v3"
+	"github.com/spandigital/cel2sql/v3/testcases"
+	"github.com/spandigital/cel2sql/v3/testutil"
+)
+
+func TestGen{{Dialect}}Expected(t *testing.T) {
+	factory := testutil.{{Dialect}}EnvFactory()
+
+	groups := []struct {
+		name  string
+		cases []testcases.ConvertTestCase
+	}{
+		{"basic", testcases.BasicTests()},
+		{"operators", testcases.OperatorTests()},
+		{"strings", testcases.StringTests()},
+		{"regex", testcases.RegexTests()},
+		{"casts", testcases.CastTests()},
+		{"arrays", testcases.ArrayTests()},
+		{"timestamps", testcases.TimestampTests()},
+		{"comprehensions", testcases.ComprehensionTests()},
+		{"json", testcases.JSONTests()},
+	}
+	for _, g := range groups {
+		fmt.Printf("\n===== %s =====\n", g.name)
+		for _, tc := range g.cases {
+			r, err := factory(tc.EnvSetup)
+			if err != nil {
+				fmt.Printf("%s: ENV ERROR: %v\n", tc.Name, err)
+				continue
+			}
+			ast, issues := r.Env.Compile(tc.CELExpr)
+			if issues != nil && issues.Err() != nil {
+				fmt.Printf("%s: COMPILE ERROR: %v\n", tc.Name, issues.Err())
+				continue
+			}
+			sql, err := cel2sql.Convert(ast, r.Opts...)
+			if err != nil {
+				fmt.Printf("%s | %s | ERROR: %v\n", tc.Name, tc.CELExpr, err)
+				continue
+			}
+			fmt.Printf("%s | %s | %s\n", tc.Name, tc.CELExpr, sql)
+		}
+	}
+
+	fmt.Printf("\n===== parameterized =====\n")
+	for _, tc := range testcases.ParameterizedTests() {
+		r, err := factory(tc.EnvSetup)
+		if err != nil {
+			fmt.Printf("%s: ENV ERROR: %v\n", tc.Name, err)
+			continue
+		}
+		ast, issues := r.Env.Compile(tc.CELExpr)
+		if issues != nil && issues.Err() != nil {
+			fmt.Printf("%s: COMPILE ERROR: %v\n", tc.Name, issues.Err())
+			continue
+		}
+		result, err := cel2sql.ConvertParameterized(ast, r.Opts...)
+		if err != nil {
+			fmt.Printf("%s | %s | ERROR: %v\n", tc.Name, tc.CELExpr, err)
+			continue
+		}
+		fmt.Printf("%s | %s | %s | %v\n", tc.Name, tc.CELExpr, result.SQL, result.Parameters)
+	}
+}

--- a/.claude/skills/release-cel2sql/SKILL.md
+++ b/.claude/skills/release-cel2sql/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: release-cel2sql
+description: Cuts a new cel2sql release by preparing CHANGELOG.md, deciding the semver bump from commit history, opening a release-prep PR, then tagging and pushing after merge to trigger .github/workflows/release.yml. Use when shipping any new patch, minor, or major version of cel2sql.
+---
+
+# Release cel2sql
+
+The release flow is short but easy to mess up — direct push to `main` is blocked, the CHANGELOG `[Unreleased]` block has to be split into a versioned section first, and the semver decision interacts with semantic-import-versioning (`/v3` → `/v4` is a major).
+
+## Quick start
+
+```
+git checkout main && git pull --ff-only origin main
+LAST=$(git describe --tags --abbrev=0)
+git log "$LAST..main" --oneline                              # commits to release
+python .claude/skills/release-cel2sql/scripts/prepare_release.py X.Y.Z  # patches CHANGELOG
+git checkout -b chore/release-vX.Y.Z
+git add CHANGELOG.md
+git commit -m "chore: prepare CHANGELOG for vX.Y.Z release"
+git push -u origin chore/release-vX.Y.Z
+gh pr create --title "chore: prepare CHANGELOG for vX.Y.Z release" --body "..."
+# After PR merges:
+git checkout main && git pull --ff-only origin main
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z   # triggers .github/workflows/release.yml
+```
+
+The tag push triggers the release workflow, which runs tests + builds + creates the GitHub release with auto-generated notes from PR titles.
+
+## Picking the version
+
+See [references/semver-decision.md](references/semver-decision.md). Quick rules:
+
+- **Patch** — dependency bumps that don't change behavior, doc-only fixes, test fixes.
+- **Minor** — new feature, new option, new dialect.
+- **Major** — requires module-path change `/v3` → `/v4`. Reserve for genuinely user-disruptive breakage. The Observe heuristic-removal in #113 was BREAKING but stayed within v3 because its blast radius was niche.
+
+When unsure between patch and minor: if any user-visible API surface changed (new exported function/option/method, new dialect, new CEL feature), bump minor.
+
+## Common slip-ups
+
+- **Stale `[Unreleased]` content from a prior release.** When the previous version was tagged, its content stayed under `## [Unreleased]` instead of being moved to `## [3.x.y] - <date>`. Happened with v3.6.0: the multi-dialect entry sat under `[Unreleased]` until v3.7.0, then had to be backfilled. The `prepare_release.py` script handles this by inspecting the existing `[Unreleased]` block before rewriting.
+- **Direct push to main blocked.** A direct `git push origin main` for the CHANGELOG commit will fail with the project's branch-protection rules. Always use a `chore/release-vX.Y.Z` branch and a release-prep PR.
+- **Forgetting the tag annotation.** Use `git tag -a` (annotated) not `git tag` (lightweight). The release workflow reads the tag message.
+
+## Verification
+
+After pushing the tag, monitor the release workflow:
+
+```
+gh run list --workflow Release --limit 1 --repo SPANDigital/cel2sql --json databaseId,status,headBranch
+gh run watch <run-id>
+```
+
+The workflow runs unit tests, builds, then creates the GitHub release using `softprops/action-gh-release@v2` with `generate_release_notes: true`. If it fails on stdlib vulns or a transitive dep CVE, that fix is *out of scope for this skill* — flag it as a follow-up dep-bump PR. The tagged release will not exist on GitHub until the workflow succeeds.
+
+## Resources
+
+- [references/semver-decision.md](references/semver-decision.md) — patch/minor/major decision tree, including the SIV `/v4` caveat.
+- **Run** `python scripts/prepare_release.py vX.Y.Z` (or just `X.Y.Z`) — reads `CHANGELOG.md`, splits `[Unreleased]` into a versioned section dated today, prints a checklist of commits since the last tag and the commit/tag commands.

--- a/.claude/skills/release-cel2sql/references/semver-decision.md
+++ b/.claude/skills/release-cel2sql/references/semver-decision.md
@@ -1,0 +1,61 @@
+# Semver Decision Tree for cel2sql
+
+cel2sql uses Go semantic-import-versioning (SIV): the major version is encoded in the module path (`github.com/spandigital/cel2sql/v3`). A major bump is a module-path change that all downstream consumers must update.
+
+## Contents
+
+- Decision tree
+- The SIV /v4 caveat
+- Examples from history
+- Breaking changes that stayed within v3
+
+## Decision tree
+
+| Change shape | Bump |
+|---|---|
+| Dependency upgrade with no behavior change | Patch |
+| Doc-only fix | Patch |
+| Test-only fix (e.g. resolving spurious CI annotations like #115) | Patch |
+| Bug fix in SQL output that *narrows* output to be correct | Patch |
+| New option (e.g. `WithJSONVariables`, `WithColumnAliases`) | Minor |
+| New CEL feature exposed in default env | Minor |
+| New dialect | Minor |
+| New exported function on the public API | Minor |
+| Removing or renaming any exported symbol | Major *only if* SIV path change is justified — see caveat |
+| Changing the signature of an exported function | Major *only if* SIV path change is justified |
+| Removing a registered dialect | Major |
+| Module path change | Major |
+
+## The SIV /v4 caveat
+
+A major version bump in Go means renaming the module path from `github.com/spandigital/cel2sql/v3` to `github.com/spandigital/cel2sql/v4`. Every consumer must update their imports. This is **expensive churn** for the ecosystem — bump major only when the breakage is large enough to justify it.
+
+In practice this means:
+- Niche behavior fixes, even if technically breaking, can stay within v3 if accompanied by a prominent `### Changed (BREAKING)` CHANGELOG entry.
+- Genuine API redesigns (the v3.0 BigQuery → PostgreSQL migration; a hypothetical re-shape of `dialect.Dialect`) warrant a major bump.
+
+## Examples from history
+
+- **v3.0.0**: BigQuery → PostgreSQL migration. Removed `cloud.google.com/go/bigquery` dependency. Required all consumers to refactor. Major.
+- **v3.6.0**: Multi-dialect support added (MySQL, SQLite, DuckDB, BigQuery). Additive. Minor.
+- **v3.7.0**: WithJSONVariables, WithColumnAliases, WithParamStartIndex options added; name-based numeric-cast heuristic removed. Last item was BREAKING but narrow (only affected callers using variables literally named `score` / `value` / `num` / `amount` / `count` / `level` for non-JSON usage). Stayed minor with a `### Changed (BREAKING)` flag.
+- **v3.7.1**: Spurious `##[error]` annotation fix (#115) + dependabot dep bumps. Patch.
+- **v3.8.0** *(forthcoming when Spark merges)*: New Spark dialect. Additive. Minor.
+
+## Breaking changes that stayed within v3
+
+The Observe heuristic-removal (#113) is the canonical example. The CHANGELOG entry:
+
+```markdown
+### Changed
+- **BREAKING: Removed name-based numeric-cast heuristic in `visitIdent`** —
+  identifiers named `score`, `value`, `num`, `amount`, `count`, or `level`
+  are no longer auto-cast to `::numeric`. The heuristic was a footgun that
+  incorrectly cast plain (non-JSON) variables that happened to share these
+  names. Numeric casting is now driven solely by JSON text-extraction
+  context (handled in `visitCall`). Callers that relied on the implicit
+  cast should add an explicit cast in CEL or use the JSON comprehension
+  paths. Backported from observeinc/cel2sql fork PR #1.
+```
+
+The `### Changed (BREAKING)` heading and the migration-guidance final sentence are load-bearing — they signal to consumers what to do. Without that note, the `/v4` bump becomes the only safe option.

--- a/.claude/skills/release-cel2sql/scripts/prepare_release.py
+++ b/.claude/skills/release-cel2sql/scripts/prepare_release.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Prepare CHANGELOG.md for a cel2sql release.
+
+Usage: python prepare_release.py vX.Y.Z   (or just X.Y.Z)
+
+What it does:
+  1. Reads CHANGELOG.md from the repo root.
+  2. Finds the `## [Unreleased]` section.
+  3. Errors out if [Unreleased] is empty.
+  4. Renames `## [Unreleased]` → `## [X.Y.Z] - <today>` and inserts a fresh
+     empty `## [Unreleased]` heading above it.
+  5. Writes CHANGELOG.md back in place.
+  6. Prints a checklist of commits since the last tag, plus the suggested
+     follow-up commands (branch, commit, PR, tag, push).
+
+Exits 0 on success. Use --check to dry-run (print the would-be output without
+modifying CHANGELOG.md).
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_repo_root() -> Path:
+    cur = Path.cwd().resolve()
+    for d in [cur, *cur.parents]:
+        if (d / "go.mod").exists() and (d / "CHANGELOG.md").exists():
+            return d
+    raise SystemExit("error: run from cel2sql repo root (go.mod and CHANGELOG.md must be siblings)")
+
+
+SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+UNRELEASED_HEAD_RE = re.compile(r"^## \[Unreleased\]\s*$", re.M)
+NEXT_HEAD_RE = re.compile(r"^## \[", re.M)
+
+
+def parse_version(arg: str) -> str:
+    m = SEMVER_RE.match(arg.strip())
+    if not m:
+        raise SystemExit(f"error: version {arg!r} must look like X.Y.Z or vX.Y.Z")
+    return f"{m.group(1)}.{m.group(2)}.{m.group(3)}"
+
+
+def split_changelog(text: str) -> tuple[str, str, str]:
+    """Return (head, unreleased_block, tail).
+
+    head is the prefix before `## [Unreleased]`, unreleased_block is the
+    Unreleased section content (without the heading), tail is everything
+    from the next `## [...]` heading onward.
+    """
+    head_match = UNRELEASED_HEAD_RE.search(text)
+    if not head_match:
+        raise SystemExit("error: CHANGELOG.md has no `## [Unreleased]` section")
+
+    after_heading = head_match.end()
+    next_match = NEXT_HEAD_RE.search(text, after_heading)
+    if not next_match:
+        raise SystemExit("error: CHANGELOG.md has no version section after `## [Unreleased]`")
+
+    head = text[: head_match.start()]
+    unreleased = text[after_heading : next_match.start()]
+    tail = text[next_match.start() :]
+    return head, unreleased, tail
+
+
+def is_empty_unreleased(block: str) -> bool:
+    """The Unreleased section is empty if it contains only blank lines."""
+    return all(not line.strip() for line in block.splitlines())
+
+
+def rewrite_changelog(text: str, version: str, today: str) -> str:
+    head, unreleased, tail = split_changelog(text)
+    if is_empty_unreleased(unreleased):
+        raise SystemExit(
+            "error: `## [Unreleased]` is empty — nothing to release. "
+            "Add changelog entries first."
+        )
+
+    new = (
+        head
+        + "## [Unreleased]\n"
+        + "\n"
+        + f"## [{version}] - {today}"
+        + unreleased
+        + tail
+    )
+    return new
+
+
+def git_commits_since_last_tag() -> list[str]:
+    try:
+        last_tag = subprocess.check_output(
+            ["git", "describe", "--tags", "--abbrev=0"], text=True
+        ).strip()
+    except subprocess.CalledProcessError:
+        return ["(no prior tag — git describe failed)"]
+
+    try:
+        log = subprocess.check_output(
+            ["git", "log", f"{last_tag}..HEAD", "--oneline"], text=True
+        ).strip()
+    except subprocess.CalledProcessError as exc:
+        return [f"(git log failed: {exc})"]
+
+    if not log:
+        return ["(no commits since last tag)"]
+    return [f"  {line}" for line in log.splitlines()]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("version", help="target version, X.Y.Z or vX.Y.Z")
+    ap.add_argument("--check", action="store_true", help="dry-run; print result without writing")
+    args = ap.parse_args()
+
+    version = parse_version(args.version)
+    today = datetime.date.today().isoformat()
+
+    root = find_repo_root()
+    changelog = root / "CHANGELOG.md"
+    text = changelog.read_text(encoding="utf-8")
+
+    new_text = rewrite_changelog(text, version, today)
+
+    if args.check:
+        print("=== DRY RUN — CHANGELOG.md would become: ===")
+        # Print the diff-relevant section (the new versioned block).
+        excerpt_start = new_text.find(f"## [{version}] - {today}")
+        if excerpt_start >= 0:
+            excerpt_end = new_text.find("## [", excerpt_start + 1)
+            print(new_text[excerpt_start:excerpt_end].rstrip())
+        return
+
+    changelog.write_text(new_text, encoding="utf-8")
+    print(f"✓ CHANGELOG.md updated: [Unreleased] → [{version}] - {today}\n")
+
+    print("Commits since last tag:")
+    for line in git_commits_since_last_tag():
+        print(line)
+
+    print()
+    print("Suggested next steps:")
+    print(f"  git checkout -b chore/release-v{version}")
+    print(f"  git add CHANGELOG.md")
+    print(f"  git commit -m 'chore: prepare CHANGELOG for v{version} release'")
+    print(f"  git push -u origin chore/release-v{version}")
+    print(f"  gh pr create --title 'chore: prepare CHANGELOG for v{version} release' --body '...'")
+    print()
+    print("After the PR merges:")
+    print(f"  git checkout main && git pull --ff-only origin main")
+    print(f"  git tag -a v{version} -m 'Release v{version}'")
+    print(f"  git push origin v{version}      # triggers .github/workflows/release.yml")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Re-targets [#119](https://github.com/SPANDigital/cel2sql/pull/119) onto `main`. The original PR was stacked on `feat/add-skill-authoring-skill` (which became #118), and after #118 was squash-merged into main, GitHub merged #119's content into the now-stale branch instead of into main. Net result: `skill-authoring/` is on main, but `add-sql-dialect/`, `add-cel-feature/`, and `release-cel2sql/` are not.

This PR cherry-picks the three-skills commit onto a fresh branch off main. Content is identical to #119.

## What lands

- `.claude/skills/add-sql-dialect/` — SKILL.md + dialect-method matrix + touchpoints checklist + `check_testcase_coverage.py` + `gen_expected_sql.go.tmpl`.
- `.claude/skills/add-cel-feature/` — SKILL.md + converter-file-map + dialect-method-checklist.
- `.claude/skills/release-cel2sql/` — SKILL.md + semver-decision + `prepare_release.py`.

## Verification

```
$ python .claude/skills/skill-authoring/scripts/lint_skill.py .claude/skills/add-sql-dialect
0 error(s), 0 warning(s)
$ python .claude/skills/skill-authoring/scripts/lint_skill.py .claude/skills/add-cel-feature
0 error(s), 0 warning(s)
$ python .claude/skills/skill-authoring/scripts/lint_skill.py .claude/skills/release-cel2sql
0 error(s), 0 warning(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)