### PR TITLE
chore: prepare CHANGELOG for v3.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [3.8.2] - 2026-05-01
+### Changed
+- **Dependencies**
+  - `google.golang.org/api` 0.276.0 → 0.277.0 (#128)
+  - `github.com/go-sql-driver/mysql` 1.9.3 → 1.10.0 (#127)
+
 ## [3.8.1] - 2026-04-27
 ### Changed
 - **Dependencies**


### PR DESCRIPTION
## Summary
- Splits `[Unreleased]` into `[3.8.2] - 2026-05-01` in CHANGELOG.md
- Patch release covering two dependency bumps merged since v3.8.1

## Changes since v3.8.1
- `google.golang.org/api` 0.276.0 → 0.277.0 (#128)
- `github.com/go-sql-driver/mysql` 1.9.3 → 1.10.0 (#127)

## Test plan
- [ ] Merge this PR
- [ ] Tag `v3.8.2` on main and push to trigger `.github/workflows/release.yml`
- [ ] Verify Release workflow succeeds and the GitHub release is created