### PR TITLE
chore: prepare CHANGELOG for v3.8.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [3.8.4] - 2026-06-08
+### Changed
+- **Dependencies**
+  - `google.golang.org/api` 0.279.0 → 0.283.0 (#140)
+  - `google.golang.org/grpc` 1.81.0 → 1.81.1 (#139)
+  - `github.com/jackc/pgx/v5` 5.9.2 → 5.10.0 (#138)
+
 ## [3.8.3] - 2026-06-08
 ### Security
 - **Cleared a wave of Go security advisories** (#136) flagged by the OSV


### PR DESCRIPTION
## Summary

Prepares the CHANGELOG for the **v3.8.4** patch release. Splits `[Unreleased]` into a dated `[3.8.4]` section covering the three dependency bumps merged since v3.8.3.

Patch-level — dependency maintenance only, no API or behavior changes:

### Dependencies
- `google.golang.org/api` 0.279.0 → 0.283.0 (#140)
- `google.golang.org/grpc` 1.81.0 → 1.81.1 (#139)
- `github.com/jackc/pgx/v5` 5.9.2 → 5.10.0 (#138)

After this merges, the `v3.8.4` tag will be pushed to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)