### PR TITLE
chore: prepare CHANGELOG for v3.8.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [3.8.5] - 2026-06-14
 ### Fixed
 - **JSON array membership (`in`) now generates a correct boolean predicate on
   every dialect.** Each dialect now owns the full predicate, emitting both the


### PR DESCRIPTION
Prepares the CHANGELOG for the **v3.8.5** patch release.

Splits the `[Unreleased]` block into `## [3.8.5] - 2026-06-14`. The release covers PR #143:

- **Fix:** per-dialect JSON array `in` membership now generates a correct boolean predicate (MySQL `JSON_OVERLAPS`, SQLite/DuckDB `EXISTS … json_each`, BigQuery `IN UNNEST(JSON_VALUE_ARRAY(...))`; PostgreSQL/Spark semantics intact).
- Internal refactor (regex/validation/provider dedup, dead-code removal) — no user-facing API change.

Patch bump: a behavior-correcting bug fix with no new/changed public API surface.

After merge, tag `v3.8.5` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)