### PR TITLE
chore: prepare CHANGELOG for v3.8.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.8.6] - 2026-06-15
+### Changed
+- **Dependencies**
+  - `google.golang.org/api` 0.283.0 → 0.284.0 (#142)
+
 ## [3.8.5] - 2026-06-14
 ### Fixed
 - **JSON array membership (`in`) now generates a correct boolean predicate on


### PR DESCRIPTION
Prepares the CHANGELOG for the **v3.8.6** patch release.

## Changes since v3.8.5
- **Dependencies**: `google.golang.org/api` 0.283.0 → 0.284.0 (#142)

A patch bump — dependency-only update with no behavior change.

After merge, the `v3.8.6` tag will be pushed to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)