### PR TITLE
chore: prepare CHANGELOG for v3.8.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.8.7] - 2026-06-18
+### Changed
+- **Dependencies**
+  - `google.golang.org/api` 0.284.0 → 0.285.0 (#146)
+
 ## [3.8.6] - 2026-06-15
 ### Changed
 - **Dependencies**


### PR DESCRIPTION
## Summary
Prepare CHANGELOG for the **v3.8.7** patch release.

### Changed
- **Dependencies**
  - `google.golang.org/api` 0.284.0 → 0.285.0 (#146)

This is a patch release containing a single dependency bump (no behavior change). Tag `v3.8.7` will be pushed after this merges to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)