### PR TITLE
ci: fix dependency-update permissions and fuzz job timeout

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,7 +19,7 @@ jobs:
   fuzz:
     name: Fuzz Testing
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Fixes two recurring CI failures observed on scheduled runs:

1. **Dependency Update workflow** failed at the push step with a 403:
   `Permission to SPANDigital/cel2sql.git denied to github-actions[bot]`.
   The workflow granted only `contents: read`, but `peter-evans/create-pull-request`
   needs `contents: write` to push the `update-dependencies` branch. Changed to
   `contents: write` (kept `pull-requests: write`).

2. **Fuzzing workflow** (scheduled) timed out: it runs 3 fuzz functions at
   `-fuzztime=10m` each = 30m of fuzzing, but the job's `timeout-minutes` was also
   `30`, so it exceeded the limit before finishing (no room for checkout/setup/download).
   Raised `timeout-minutes` to `45`.

Workflow-config changes only — no application code touched.

> Note: if the Dependency Update job still can't *open* a PR after this (push will now
> succeed), the repo also needs **Settings → Actions → General → "Allow GitHub Actions
> to create and approve pull requests"** enabled — that's a repo setting, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)