### PR TITLE
fix: `json_each` on SQLite generates invalid SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- **SQLite/MySQL comprehensions**: a reference to a comprehension's iteration
+  variable now names the value rather than the source alias. `json_each` and
+  `JSON_TABLE` are table-valued functions, so `approvals.exists(a, a ==
+  "alice")` generated `WHERE a = ?` against a row of `key, value, type, …` —
+  SQL the converter reported as a success and the database rejected with
+  "no such column: a". Dialects write the reference themselves now, through
+  the new `Dialect.WriteIterVarRef`.
 
 ## [3.8.8] - 2026-06-29
 ### Changed

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -405,13 +405,17 @@ type converter struct {
 	ctx                context.Context
 	logger             *slog.Logger
 	dialect            dialect.Dialect
-	depth              int   // Current recursion depth
-	maxDepth           int   // Maximum allowed recursion depth
-	maxOutputLen       int   // Maximum allowed SQL output length
-	comprehensionDepth int   // Current comprehension nesting depth
-	parameterize       bool  // Enable parameterized output
-	parameters         []any // Collected parameters for parameterized queries
-	paramCount         int   // Parameter counter for placeholders
+	depth              int // Current recursion depth
+	maxDepth           int // Maximum allowed recursion depth
+	maxOutputLen       int // Maximum allowed SQL output length
+	comprehensionDepth int // Current comprehension nesting depth
+	// iterVars are the comprehension iteration variables in scope. A
+	// reference to one is written by the dialect, which knows whether its own
+	// source bound the alias to a value or to a row.
+	iterVars     map[string]bool
+	parameterize bool  // Enable parameterized output
+	parameters   []any // Collected parameters for parameterized queries
+	paramCount   int   // Parameter counter for placeholders
 }
 
 // checkContext checks if the context has been cancelled or expired.
@@ -2061,6 +2065,15 @@ func (con *converter) visitAllComprehension(expr *exprpb.Expr, info *Comprehensi
 		return newConversionError(errMsgUnsupportedComprehension, "expression is not a comprehension (ALL)")
 	}
 
+	// Every reference to the iteration variable is written by the dialect,
+	// which knows whether its own comprehension source binds the alias to a
+	// value or to a row. Bound before anything is written, because a filter
+	// and a map name the variable in their projection, ahead of the FROM.
+	//
+	// Restored afterwards, since comprehensions nest and an inner one may
+	// reuse a name.
+	defer con.bindIterVar(info.IterVar)()
+
 	iterRange := comprehension.GetIterRange()
 
 	con.str.WriteString("NOT EXISTS (SELECT 1 FROM ")
@@ -2088,6 +2101,15 @@ func (con *converter) visitExistsComprehension(expr *exprpb.Expr, info *Comprehe
 		return newConversionError(errMsgUnsupportedComprehension, "expression is not a comprehension (EXISTS)")
 	}
 
+	// Every reference to the iteration variable is written by the dialect,
+	// which knows whether its own comprehension source binds the alias to a
+	// value or to a row. Bound before anything is written, because a filter
+	// and a map name the variable in their projection, ahead of the FROM.
+	//
+	// Restored afterwards, since comprehensions nest and an inner one may
+	// reuse a name.
+	defer con.bindIterVar(info.IterVar)()
+
 	iterRange := comprehension.GetIterRange()
 
 	con.str.WriteString("EXISTS (SELECT 1 FROM ")
@@ -2114,6 +2136,15 @@ func (con *converter) visitExistsOneComprehension(expr *exprpb.Expr, info *Compr
 		return newConversionError(errMsgUnsupportedComprehension, "expression is not a comprehension (EXISTS_ONE)")
 	}
 
+	// Every reference to the iteration variable is written by the dialect,
+	// which knows whether its own comprehension source binds the alias to a
+	// value or to a row. Bound before anything is written, because a filter
+	// and a map name the variable in their projection, ahead of the FROM.
+	//
+	// Restored afterwards, since comprehensions nest and an inner one may
+	// reuse a name.
+	defer con.bindIterVar(info.IterVar)()
+
 	iterRange := comprehension.GetIterRange()
 
 	con.str.WriteString("(SELECT COUNT(*) FROM ")
@@ -2139,6 +2170,15 @@ func (con *converter) visitMapComprehension(expr *exprpb.Expr, info *Comprehensi
 	if comprehension == nil {
 		return newConversionError(errMsgUnsupportedComprehension, "expression is not a comprehension (MAP)")
 	}
+
+	// Every reference to the iteration variable is written by the dialect,
+	// which knows whether its own comprehension source binds the alias to a
+	// value or to a row. Bound before anything is written, because a filter
+	// and a map name the variable in their projection, ahead of the FROM.
+	//
+	// Restored afterwards, since comprehensions nest and an inner one may
+	// reuse a name.
+	defer con.bindIterVar(info.IterVar)()
 
 	iterRange := comprehension.GetIterRange()
 
@@ -2175,10 +2215,23 @@ func (con *converter) visitFilterComprehension(expr *exprpb.Expr, info *Comprehe
 		return newConversionError(errMsgUnsupportedComprehension, "expression is not a comprehension (FILTER)")
 	}
 
+	// Every reference to the iteration variable is written by the dialect,
+	// which knows whether its own comprehension source binds the alias to a
+	// value or to a row. Bound before anything is written, because a filter
+	// and a map name the variable in their projection, ahead of the FROM.
+	//
+	// Restored afterwards, since comprehensions nest and an inner one may
+	// reuse a name.
+	defer con.bindIterVar(info.IterVar)()
+
 	iterRange := comprehension.GetIterRange()
 
 	con.dialect.WriteArraySubqueryOpen(&con.str)
-	con.str.WriteString(info.IterVar)
+	// The projection names the iteration variable, so it goes through the
+	// dialect for the same reason a reference in the predicate does.
+	if err := con.dialect.WriteIterVarRef(&con.str, info.IterVar); err != nil {
+		return wrapConversionError(err, "writing the iteration variable in FILTER comprehension")
+	}
 	con.dialect.WriteArraySubqueryExprClose(&con.str)
 	con.str.WriteString(" FROM ")
 	if err := con.writeComprehensionSource(iterRange); err != nil {
@@ -2327,6 +2380,12 @@ func (con *converter) visitIdent(expr *exprpb.Expr) error {
 	// Validate identifier name for security (prevent SQL injection)
 	if err := con.dialect.ValidateFieldName(identName); err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidFieldName, err)
+	}
+
+	// An iteration variable is the dialect's to write: its alias may name a
+	// row rather than a value, depending on what the source bound it to.
+	if con.iterVars[identName] {
+		return con.dialect.WriteIterVarRef(&con.str, identName)
 	}
 
 	// Apply column alias if configured
@@ -2629,6 +2688,26 @@ func (con *converter) writeComprehensionSource(iterRange *exprpb.Expr) error {
 	return con.dialect.WriteUnnest(&con.str, func() error {
 		return con.visit(iterRange)
 	})
+}
+
+// bindIterVar records how a comprehension's iteration variable was bound, for
+// as long as its predicate is being written.
+//
+// Scoped rather than accumulated: comprehensions nest, and an inner one may
+// reuse a name the outer one bound differently. The returned function restores
+// whatever the name meant before.
+func (con *converter) bindIterVar(name string) func() {
+	if con.iterVars == nil {
+		con.iterVars = map[string]bool{}
+	}
+	had := con.iterVars[name]
+	con.iterVars[name] = true
+	return func() {
+		if had {
+			return
+		}
+		delete(con.iterVars, name)
+	}
 }
 
 func (con *converter) visitMaybeNested(expr *exprpb.Expr, nested bool) error {

--- a/dialect/bigquery/dialect.go
+++ b/dialect/bigquery/dialect.go
@@ -510,3 +510,12 @@ func bigqueryTypeName(typeName string) string {
 		return strings.ToUpper(typeName)
 	}
 }
+
+// WriteIterVarRef writes a reference to a comprehension's iteration variable.
+//
+// The alias is the value itself here: UNNEST binds one element per row to the
+// alias, so nothing has to be selected out of it.
+func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
+	w.WriteString(alias)
+	return nil
+}

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -181,6 +181,21 @@ type Dialect interface {
 
 	// --- Comprehensions ---
 
+	// WriteIterVarRef writes a reference to a comprehension's iteration
+	// variable, given the alias the source was bound to.
+	//
+	// The alias is the whole value where the source is an UNNEST-style
+	// binding, which is why the default implementation writes it unchanged.
+	// Where the source is a table-valued function it is not: SQLite's
+	// json_each yields rows of key, value, type and more, so a comparison
+	// against the array's element has to name the column that holds it.
+	//
+	// No flag for which source bound it: a dialect writes both of them, so it
+	// already knows. SQLite renders json_each for either, MySQL renders
+	// JSON_TABLE with a value column for either, and DuckDB's UNNEST binds
+	// the element itself.
+	WriteIterVarRef(w *strings.Builder, alias string) error
+
 	// WriteUnnest writes the UNNEST source for comprehensions.
 	// For PostgreSQL: UNNEST(array). For MySQL: JSON_TABLE(...).
 	WriteUnnest(w *strings.Builder, writeSource func() error) error

--- a/dialect/duckdb/dialect.go
+++ b/dialect/duckdb/dialect.go
@@ -481,3 +481,12 @@ func (d *Dialect) SupportsIndexAnalysis() bool { return true }
 func escapeJSONFieldName(fieldName string) string {
 	return strings.ReplaceAll(fieldName, "'", "''")
 }
+
+// WriteIterVarRef writes a reference to a comprehension's iteration variable.
+//
+// The alias is the value itself here: UNNEST binds one element per row to the
+// alias, so nothing has to be selected out of it.
+func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
+	w.WriteString(alias)
+	return nil
+}

--- a/dialect/mysql/dialect.go
+++ b/dialect/mysql/dialect.go
@@ -483,3 +483,16 @@ func (d *Dialect) SupportsIndexAnalysis() bool { return true }
 func escapeJSONFieldName(fieldName string) string {
 	return strings.ReplaceAll(fieldName, "'", "''")
 }
+
+// WriteIterVarRef writes a reference to a comprehension's iteration variable.
+//
+// The alias is the value itself here: UNNEST binds one element per row to the
+// alias, so nothing has to be selected out of it.
+func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
+	// JSON_TABLE is given a COLUMNS(value ...) clause by WriteUnnest and by
+	// WriteJSONArrayElements alike, so the alias names a row with one column
+	// and a reference to the element is that column.
+	w.WriteString(alias)
+	w.WriteString(".value")
+	return nil
+}

--- a/dialect/postgres/dialect.go
+++ b/dialect/postgres/dialect.go
@@ -500,3 +500,12 @@ func (d *Dialect) SupportsIndexAnalysis() bool { return true }
 func escapeJSONFieldName(fieldName string) string {
 	return strings.ReplaceAll(fieldName, "'", "''")
 }
+
+// WriteIterVarRef writes a reference to a comprehension's iteration variable.
+//
+// The alias is the value itself here: UNNEST binds one element per row to the
+// alias, so nothing has to be selected out of it.
+func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
+	w.WriteString(alias)
+	return nil
+}

--- a/dialect/spark/dialect.go
+++ b/dialect/spark/dialect.go
@@ -535,3 +535,12 @@ func sparkTypeName(typeName string) string {
 		return strings.ToUpper(typeName)
 	}
 }
+
+// WriteIterVarRef writes a reference to a comprehension's iteration variable.
+//
+// The alias is the value itself here: UNNEST binds one element per row to the
+// alias, so nothing has to be selected out of it.
+func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
+	w.WriteString(alias)
+	return nil
+}

--- a/dialect/sqlite/dialect.go
+++ b/dialect/sqlite/dialect.go
@@ -470,3 +470,20 @@ func sqliteExtractFormat(part string) string {
 		return "%Y"
 	}
 }
+
+// WriteIterVarRef writes a reference to a comprehension's iteration variable.
+//
+// json_each is a table-valued function, so the alias names a row of key,
+// value, type, atom, id, parent, fullkey and path — not the element. A
+// comparison against the array's element wants the value column, and writing
+// the bare alias produces "no such column: a" at query time from SQL the
+// converter reported as a success.
+//
+// Unconditional, because both of this dialect's comprehension sources are
+// json_each: WriteUnnest and WriteJSONArrayElements write the same function,
+// so every iteration variable here names one of its rows.
+func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
+	w.WriteString(alias)
+	w.WriteString(".value")
+	return nil
+}

--- a/sqlite_iteration_variable_test.go
+++ b/sqlite_iteration_variable_test.go
@@ -62,7 +62,7 @@ func TestSQLiteComprehensionRunsAgainstSQLite(t *testing.T) {
 			require.NoError(t, err)
 
 			rows, err := db.Query(
-				`SELECT id FROM reviews WHERE `+converted.SQL, converted.Parameters...)
+				`SELECT id FROM reviews WHERE `+converted.SQL, converted.Parameters...) //nolint:gosec // converted.SQL is parameterized output under test, not user input
 			require.NoError(t, err, "generated SQL: %s", converted.SQL)
 			defer func() { _ = rows.Close() }()
 

--- a/sqlite_iteration_variable_test.go
+++ b/sqlite_iteration_variable_test.go
@@ -1,0 +1,79 @@
+package cel2sql_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+
+	"github.com/spandigital/cel2sql/v3"
+	"github.com/spandigital/cel2sql/v3/dialect"
+	_ "github.com/spandigital/cel2sql/v3/dialect/sqlite"
+	"github.com/spandigital/cel2sql/v3/schema"
+)
+
+// TestSQLiteComprehensionRunsAgainstSQLite converts a comprehension and then
+// executes it, which is the check this needs: json_each is a table-valued
+// function, so a reference to the iteration variable that names the alias
+// rather than its value is SQL the converter reports as a success and SQLite
+// rejects with "no such column".
+func TestSQLiteComprehensionRunsAgainstSQLite(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`CREATE TABLE reviews (id INTEGER PRIMARY KEY, approvals TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO reviews (id, approvals) VALUES (1, '["alice","bob"]'), (2, '["carol"]')`)
+	require.NoError(t, err)
+
+	env, err := cel.NewEnv(cel.Variable("approvals", cel.DynType))
+	require.NoError(t, err)
+
+	fields := []schema.FieldSchema{{
+		Name: "approvals", Type: "text",
+		IsJSON: true, Repeated: true, Dimensions: 1, ElementType: "text",
+	}}
+	schemas := map[string]schema.Schema{"reviews": schema.NewSchema(fields)}
+
+	sqlite, err := dialect.Get(dialect.SQLite)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		celExpr string
+		wantIDs []int
+	}{
+		{name: "exists", celExpr: `approvals.exists(a, a == "alice")`, wantIDs: []int{1}},
+		{name: "exists none", celExpr: `approvals.exists(a, a == "nobody")`},
+		{name: "all", celExpr: `approvals.all(a, a != "carol")`, wantIDs: []int{1}},
+		{name: "exists_one", celExpr: `approvals.exists_one(a, a == "carol")`, wantIDs: []int{2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, iss := env.Compile(tt.celExpr)
+			require.NoError(t, iss.Err())
+
+			converted, err := cel2sql.ConvertParameterized(ast,
+				cel2sql.WithDialect(sqlite), cel2sql.WithSchemas(schemas))
+			require.NoError(t, err)
+
+			rows, err := db.Query(
+				`SELECT id FROM reviews WHERE `+converted.SQL, converted.Parameters...)
+			require.NoError(t, err, "generated SQL: %s", converted.SQL)
+			defer func() { _ = rows.Close() }()
+
+			var ids []int
+			for rows.Next() {
+				var id int
+				require.NoError(t, rows.Scan(&id))
+				ids = append(ids, id)
+			}
+			require.NoError(t, rows.Err())
+			require.Equal(t, tt.wantIDs, ids, "generated SQL: %s", converted.SQL)
+		})
+	}
+}

--- a/testcases/comprehension_tests.go
+++ b/testcases/comprehension_tests.go
@@ -11,7 +11,7 @@ func ComprehensionTests() []ConvertTestCase {
 			Category: CategoryComprehension,
 			WantSQL: map[dialect.Name]string{
 				dialect.PostgreSQL: "NOT EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE NOT (x != 'bad'))",
-				dialect.SQLite:     "NOT EXISTS (SELECT 1 FROM json_each(string_list) AS x WHERE NOT (x != 'bad'))",
+				dialect.SQLite:     "NOT EXISTS (SELECT 1 FROM json_each(string_list) AS x WHERE NOT (x.value != 'bad'))",
 				dialect.DuckDB:     "NOT EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE NOT (x != 'bad'))",
 				dialect.BigQuery:   "NOT EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE NOT (x != 'bad'))",
 				dialect.Spark:      "NOT EXISTS (SELECT 1 FROM EXPLODE(string_list) AS x WHERE NOT (x != 'bad'))",
@@ -23,7 +23,7 @@ func ComprehensionTests() []ConvertTestCase {
 			Category: CategoryComprehension,
 			WantSQL: map[dialect.Name]string{
 				dialect.PostgreSQL: "EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE x = 'good')",
-				dialect.SQLite:     "EXISTS (SELECT 1 FROM json_each(string_list) AS x WHERE x = 'good')",
+				dialect.SQLite:     "EXISTS (SELECT 1 FROM json_each(string_list) AS x WHERE x.value = 'good')",
 				dialect.DuckDB:     "EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE x = 'good')",
 				dialect.BigQuery:   "EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE x = 'good')",
 				dialect.Spark:      "EXISTS (SELECT 1 FROM EXPLODE(string_list) AS x WHERE x = 'good')",
@@ -35,7 +35,7 @@ func ComprehensionTests() []ConvertTestCase {
 			Category: CategoryComprehension,
 			WantSQL: map[dialect.Name]string{
 				dialect.PostgreSQL: "(SELECT COUNT(*) FROM UNNEST(string_list) AS x WHERE x = 'unique') = 1",
-				dialect.SQLite:     "(SELECT COUNT(*) FROM json_each(string_list) AS x WHERE x = 'unique') = 1",
+				dialect.SQLite:     "(SELECT COUNT(*) FROM json_each(string_list) AS x WHERE x.value = 'unique') = 1",
 				dialect.DuckDB:     "(SELECT COUNT(*) FROM UNNEST(string_list) AS x WHERE x = 'unique') = 1",
 				dialect.BigQuery:   "(SELECT COUNT(*) FROM UNNEST(string_list) AS x WHERE x = 'unique') = 1",
 				dialect.Spark:      "(SELECT COUNT(*) FROM EXPLODE(string_list) AS x WHERE x = 'unique') = 1",
@@ -47,7 +47,7 @@ func ComprehensionTests() []ConvertTestCase {
 			Category: CategoryComprehension,
 			WantSQL: map[dialect.Name]string{
 				dialect.PostgreSQL: "ARRAY(SELECT x FROM UNNEST(string_list) AS x WHERE x != 'bad')",
-				dialect.SQLite:     "(SELECT json_group_array(x) FROM json_each(string_list) AS x WHERE x != 'bad')",
+				dialect.SQLite:     "(SELECT json_group_array(x.value) FROM json_each(string_list) AS x WHERE x.value != 'bad')",
 				dialect.DuckDB:     "ARRAY(SELECT x FROM UNNEST(string_list) AS x WHERE x != 'bad')",
 				dialect.BigQuery:   "ARRAY(SELECT x FROM UNNEST(string_list) AS x WHERE x != 'bad')",
 				dialect.Spark:      "(SELECT collect_list(x) FROM EXPLODE(string_list) AS x WHERE x != 'bad')",
@@ -59,7 +59,7 @@ func ComprehensionTests() []ConvertTestCase {
 			Category: CategoryComprehension,
 			WantSQL: map[dialect.Name]string{
 				dialect.PostgreSQL: "ARRAY(SELECT x || '_suffix' FROM UNNEST(string_list) AS x)",
-				dialect.SQLite:     "(SELECT json_group_array(x || '_suffix') FROM json_each(string_list) AS x)",
+				dialect.SQLite:     "(SELECT json_group_array(x.value || '_suffix') FROM json_each(string_list) AS x)",
 				dialect.DuckDB:     "ARRAY(SELECT x || '_suffix' FROM UNNEST(string_list) AS x)",
 				dialect.BigQuery:   "ARRAY(SELECT x || '_suffix' FROM UNNEST(string_list) AS x)",
 				dialect.Spark:      "(SELECT collect_list(concat(x, '_suffix')) FROM EXPLODE(string_list) AS x)",


### PR DESCRIPTION
Fixes #168.

SQLIte's [json_each](https://sqlite.org/json1.html#jeach) and MySQL's [JSON_TABLE](https://dev.mysql.com/doc/refman/8.4/en/json-table-functions.html#function_json-table) are table-valued functions, and `cel2sql` generates invalid SQL for them, breaking the ability to do comprehensions across JSON fields.

For example, for SQLite `approval.exists(a, a == "alice")` generates this SQL:

```sql
EXISTS (SELECT 1 FROM json_each(approvals) AS a WHERE a = ?)
```

However, for SQLite rejects this with `no such column: a` at query time.  The correct SQL would be

```sql
EXISTS (SELECT 1 FROM json_each(approvals) AS a WHERE a.value = ?)
```

Since JSON handling isn't standardized in SQL, each dialect support is slightly different:

- **BigQuery, DuckDB, PostgreSQL, Spark**: `UNNEST` and `EXPLODE` are row-valued and work as-is.
- **SQLite and MySQL**: `json_each` and `JSON_TABLE` are table-valued and do not work.

This PR allows dialects to generate the correct syntax for JSON comprehensions and fixes SQLite and MySQL.

## Scope

`all`, `exists`, `exists_one`, `filter` and `map` all go through the same source writer, so all five were affected.

## Tests

`sqlite_iteration_variable_test.go` converts and then **executes** against an in-memory SQLite database, asserting the rows that come back. That is the check this bug asks for: the previous expectations were SQL that parsed and could not run. Against `main` it fails with `no such column: a`.

The shared SQLite expectations in `testcases/comprehension_tests.go` encoded the old output and are updated; they are the same five comprehensions.

`go test ./...` is otherwise unchanged from `main` on this machine — the 27 failures before and after are the testcontainers suites, which need Docker.

## Note on the MySQL change

I included MySQL because `WriteUnnest` there emits `JSON_TABLE(… COLUMNS(value TEXT PATH '$'))`, which is also table-valued, although the exact structure is slightly different. I could not execute against MySQL here, so that half is untested.  I can split it out into its own PR if you'd prefer.
