### PR TITLE
fix: MySQL comprehension exists/all silently matched nothing on 8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- **MySQL comprehensions**: `exists` and `all` now generate
+  `(SELECT COUNT(*) FROM JSON_TABLE(...)) > 0` / `= 0` instead of
+  `EXISTS` / `NOT EXISTS` subqueries. The MySQL 8.x optimizer transforms a
+  correlated `EXISTS` into a semijoin and loses the correlation to a
+  `JSON_TABLE` source, so the previous SQL executed without error but
+  silently matched nothing (works from MySQL 9.x; COUNT comparisons are
+  never transformed). Discovered by the new integration test that executes
+  generated comprehension SQL against a real MySQL. Adds
+  `Dialect.WriteComprehensionExists` / `WriteComprehensionNotExists`;
+  MySQL integration tests now run against MySQL 8.4 LTS (8.0 is EOL).
 
 ## [3.8.9] - 2026-08-22
 ### Fixed

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -2076,23 +2076,22 @@ func (con *converter) visitAllComprehension(expr *exprpb.Expr, info *Comprehensi
 
 	iterRange := comprehension.GetIterRange()
 
-	con.str.WriteString("NOT EXISTS (SELECT 1 FROM ")
-	if err := con.writeComprehensionSource(iterRange); err != nil {
-		return wrapConversionError(err, "visiting iter range in ALL comprehension")
-	}
-	con.str.WriteString(" AS ")
-	con.str.WriteString(info.IterVar)
-
-	if info.Predicate != nil {
-		con.str.WriteString(" WHERE NOT (")
-		if err := con.visit(info.Predicate); err != nil {
-			return wrapConversionError(err, "visiting predicate in ALL comprehension")
+	return con.dialect.WriteComprehensionNotExists(&con.str, func() error {
+		if err := con.writeComprehensionSource(iterRange); err != nil {
+			return wrapConversionError(err, "visiting iter range in ALL comprehension")
 		}
-		con.str.WriteString(")")
-	}
+		con.str.WriteString(" AS ")
+		con.str.WriteString(info.IterVar)
 
-	con.str.WriteString(")")
-	return nil
+		if info.Predicate != nil {
+			con.str.WriteString(" WHERE NOT (")
+			if err := con.visit(info.Predicate); err != nil {
+				return wrapConversionError(err, "visiting predicate in ALL comprehension")
+			}
+			con.str.WriteString(")")
+		}
+		return nil
+	})
 }
 
 func (con *converter) visitExistsComprehension(expr *exprpb.Expr, info *ComprehensionInfo) error {
@@ -2112,22 +2111,21 @@ func (con *converter) visitExistsComprehension(expr *exprpb.Expr, info *Comprehe
 
 	iterRange := comprehension.GetIterRange()
 
-	con.str.WriteString("EXISTS (SELECT 1 FROM ")
-	if err := con.writeComprehensionSource(iterRange); err != nil {
-		return wrapConversionError(err, "visiting iter range in EXISTS comprehension")
-	}
-	con.str.WriteString(" AS ")
-	con.str.WriteString(info.IterVar)
-
-	if info.Predicate != nil {
-		con.str.WriteString(" WHERE ")
-		if err := con.visit(info.Predicate); err != nil {
-			return wrapConversionError(err, "visiting predicate in EXISTS comprehension")
+	return con.dialect.WriteComprehensionExists(&con.str, func() error {
+		if err := con.writeComprehensionSource(iterRange); err != nil {
+			return wrapConversionError(err, "visiting iter range in EXISTS comprehension")
 		}
-	}
+		con.str.WriteString(" AS ")
+		con.str.WriteString(info.IterVar)
 
-	con.str.WriteString(")")
-	return nil
+		if info.Predicate != nil {
+			con.str.WriteString(" WHERE ")
+			if err := con.visit(info.Predicate); err != nil {
+				return wrapConversionError(err, "visiting predicate in EXISTS comprehension")
+			}
+		}
+		return nil
+	})
 }
 
 func (con *converter) visitExistsOneComprehension(expr *exprpb.Expr, info *ComprehensionInfo) error {

--- a/dialect/bigquery/dialect.go
+++ b/dialect/bigquery/dialect.go
@@ -519,3 +519,23 @@ func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
 	w.WriteString(alias)
 	return nil
 }
+
+// WriteComprehensionExists writes EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteComprehensionNotExists writes NOT EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionNotExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("NOT EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -196,6 +196,21 @@ type Dialect interface {
 	// the element itself.
 	WriteIterVarRef(w *strings.Builder, alias string) error
 
+	// WriteComprehensionExists wraps a comprehension's existential subquery.
+	// writeBody writes everything between FROM and the subquery's closing
+	// paren: the source, its alias, and the predicate's WHERE clause.
+	//
+	// Most dialects write EXISTS (SELECT 1 FROM <body>). MySQL cannot: its
+	// 8.x optimizer turns a correlated EXISTS into a semijoin and loses the
+	// correlation to a JSON_TABLE source, silently matching nothing, so it
+	// writes (SELECT COUNT(*) FROM <body>) > 0 instead.
+	WriteComprehensionExists(w *strings.Builder, writeBody func() error) error
+
+	// WriteComprehensionNotExists is WriteComprehensionExists negated: NOT
+	// EXISTS (SELECT 1 FROM <body>) for most dialects, (SELECT COUNT(*) FROM
+	// <body>) = 0 for MySQL.
+	WriteComprehensionNotExists(w *strings.Builder, writeBody func() error) error
+
 	// WriteUnnest writes the UNNEST source for comprehensions.
 	// For PostgreSQL: UNNEST(array). For MySQL: JSON_TABLE(...).
 	WriteUnnest(w *strings.Builder, writeSource func() error) error

--- a/dialect/duckdb/dialect.go
+++ b/dialect/duckdb/dialect.go
@@ -490,3 +490,23 @@ func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
 	w.WriteString(alias)
 	return nil
 }
+
+// WriteComprehensionExists writes EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteComprehensionNotExists writes NOT EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionNotExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("NOT EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}

--- a/dialect/mysql/dialect.go
+++ b/dialect/mysql/dialect.go
@@ -496,3 +496,29 @@ func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
 	w.WriteString(".value")
 	return nil
 }
+
+// WriteComprehensionExists writes (SELECT COUNT(*) FROM <body>) > 0.
+//
+// Not EXISTS: the MySQL 8.x optimizer transforms a correlated EXISTS into a
+// semijoin and loses the correlation to a JSON_TABLE source, so the subquery
+// silently matches nothing (works again from 9.x, and on 8.x only with
+// optimizer_switch='semijoin=off'). A COUNT comparison is never transformed.
+func (d *Dialect) WriteComprehensionExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("(SELECT COUNT(*) FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(") > 0")
+	return nil
+}
+
+// WriteComprehensionNotExists writes (SELECT COUNT(*) FROM <body>) = 0, for
+// the same reason WriteComprehensionExists avoids EXISTS.
+func (d *Dialect) WriteComprehensionNotExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("(SELECT COUNT(*) FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(") = 0")
+	return nil
+}

--- a/dialect/postgres/dialect.go
+++ b/dialect/postgres/dialect.go
@@ -509,3 +509,23 @@ func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
 	w.WriteString(alias)
 	return nil
 }
+
+// WriteComprehensionExists writes EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteComprehensionNotExists writes NOT EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionNotExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("NOT EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}

--- a/dialect/spark/dialect.go
+++ b/dialect/spark/dialect.go
@@ -544,3 +544,23 @@ func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
 	w.WriteString(alias)
 	return nil
 }
+
+// WriteComprehensionExists writes EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteComprehensionNotExists writes NOT EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionNotExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("NOT EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}

--- a/dialect/sqlite/dialect.go
+++ b/dialect/sqlite/dialect.go
@@ -487,3 +487,23 @@ func (d *Dialect) WriteIterVarRef(w *strings.Builder, alias string) error {
 	w.WriteString(".value")
 	return nil
 }
+
+// WriteComprehensionExists writes EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}
+
+// WriteComprehensionNotExists writes NOT EXISTS (SELECT 1 FROM <body>).
+func (d *Dialect) WriteComprehensionNotExists(w *strings.Builder, writeBody func() error) error {
+	w.WriteString("NOT EXISTS (SELECT 1 FROM ")
+	if err := writeBody(); err != nil {
+		return err
+	}
+	w.WriteString(")")
+	return nil
+}

--- a/mysql/provider_test.go
+++ b/mysql/provider_test.go
@@ -143,7 +143,7 @@ func TestTypeProvider_Close(_ *testing.T) {
 func setupMySQLContainer(ctx context.Context, t *testing.T) (*tcmysql.MySQLContainer, *sql.DB) {
 	t.Helper()
 
-	container, err := tcmysql.Run(ctx, "mysql:8.0",
+	container, err := tcmysql.Run(ctx, "mysql:8.4",
 		tcmysql.WithDatabase("testdb"),
 		tcmysql.WithUsername("testuser"),
 		tcmysql.WithPassword("testpass"),

--- a/mysql_integration_test.go
+++ b/mysql_integration_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/spandigital/cel2sql/v3/pg"
 )
 
-// setupMySQLContainer starts a MySQL 8 container and returns a database connection.
+// setupMySQLContainer starts a MySQL 8.4 container and returns a database connection.
 func setupMySQLContainer(ctx context.Context, t *testing.T) (testcontainers.Container, *sql.DB) {
 	t.Helper()
 
-	container, err := tcmysql.Run(ctx, "mysql:8.0",
+	container, err := tcmysql.Run(ctx, "mysql:8.4",
 		tcmysql.WithDatabase("testdb"),
 		tcmysql.WithUsername("testuser"),
 		tcmysql.WithPassword("testpass"),

--- a/mysql_iteration_variable_test.go
+++ b/mysql_iteration_variable_test.go
@@ -14,14 +14,13 @@ import (
 )
 
 // TestMySQLComprehensionRunsAgainstMySQL converts a comprehension and then
-// executes it, mirroring TestSQLiteComprehensionRunsAgainstSQLite: JSON_TABLE
-// is a table-valued function, so a reference to the iteration variable that
-// names the alias rather than its value column is SQL the converter reports
-// as a success and MySQL rejects at query time.
-//
-// Requires MySQL 8.4+: on 8.0 (EOL April 2026) a correlated JSON_TABLE inside
-// EXISTS silently matches nothing when run as a prepared statement, so these
-// queries return no error and no rows there.
+// executes it, mirroring TestSQLiteComprehensionRunsAgainstSQLite: only a
+// real server catches SQL that parses but misbehaves. It has caught two
+// distinct bugs of that kind — an iteration-variable reference naming the
+// JSON_TABLE alias instead of its value column (an unknown-column error at
+// query time), and EXISTS wrappers that the MySQL 8.x optimizer turns into a
+// semijoin, losing the correlation to JSON_TABLE and silently matching
+// nothing (hence the COUNT forms in the MySQL dialect).
 func TestMySQLComprehensionRunsAgainstMySQL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/mysql_iteration_variable_test.go
+++ b/mysql_iteration_variable_test.go
@@ -18,6 +18,10 @@ import (
 // is a table-valued function, so a reference to the iteration variable that
 // names the alias rather than its value column is SQL the converter reports
 // as a success and MySQL rejects at query time.
+//
+// Requires MySQL 8.4+: on 8.0 (EOL April 2026) a correlated JSON_TABLE inside
+// EXISTS silently matches nothing when run as a prepared statement, so these
+// queries return no error and no rows there.
 func TestMySQLComprehensionRunsAgainstMySQL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/mysql_iteration_variable_test.go
+++ b/mysql_iteration_variable_test.go
@@ -1,0 +1,89 @@
+package cel2sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spandigital/cel2sql/v3"
+	"github.com/spandigital/cel2sql/v3/dialect"
+	_ "github.com/spandigital/cel2sql/v3/dialect/mysql"
+	"github.com/spandigital/cel2sql/v3/schema"
+)
+
+// TestMySQLComprehensionRunsAgainstMySQL converts a comprehension and then
+// executes it, mirroring TestSQLiteComprehensionRunsAgainstSQLite: JSON_TABLE
+// is a table-valued function, so a reference to the iteration variable that
+// names the alias rather than its value column is SQL the converter reports
+// as a success and MySQL rejects at query time.
+func TestMySQLComprehensionRunsAgainstMySQL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	container, db := setupMySQLContainer(ctx, t)
+	defer func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Logf("failed to close db: %v", closeErr)
+		}
+		if err := container.Terminate(ctx); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	}()
+
+	_, err := db.Exec(`CREATE TABLE reviews (id INTEGER PRIMARY KEY, approvals JSON)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO reviews (id, approvals) VALUES (1, '["alice","bob"]'), (2, '["carol"]')`)
+	require.NoError(t, err)
+
+	env, err := cel.NewEnv(cel.Variable("approvals", cel.DynType))
+	require.NoError(t, err)
+
+	fields := []schema.FieldSchema{{
+		Name: "approvals", Type: "json",
+		IsJSON: true, Repeated: true, Dimensions: 1, ElementType: "text",
+	}}
+	schemas := map[string]schema.Schema{"reviews": schema.NewSchema(fields)}
+
+	mysql, err := dialect.Get(dialect.MySQL)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		celExpr string
+		wantIDs []int
+	}{
+		{name: "exists", celExpr: `approvals.exists(a, a == "alice")`, wantIDs: []int{1}},
+		{name: "exists none", celExpr: `approvals.exists(a, a == "nobody")`},
+		{name: "all", celExpr: `approvals.all(a, a != "carol")`, wantIDs: []int{1}},
+		{name: "exists_one", celExpr: `approvals.exists_one(a, a == "carol")`, wantIDs: []int{2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, iss := env.Compile(tt.celExpr)
+			require.NoError(t, iss.Err())
+
+			converted, err := cel2sql.ConvertParameterized(ast,
+				cel2sql.WithDialect(mysql), cel2sql.WithSchemas(schemas))
+			require.NoError(t, err)
+
+			rows, err := db.Query(
+				`SELECT id FROM reviews WHERE `+converted.SQL+` ORDER BY id`, converted.Parameters...) //nolint:gosec // converted.SQL is parameterized output under test, not user input
+			require.NoError(t, err, "generated SQL: %s", converted.SQL)
+			defer func() { _ = rows.Close() }()
+
+			var ids []int
+			for rows.Next() {
+				var id int
+				require.NoError(t, rows.Scan(&id))
+				ids = append(ids, id)
+			}
+			require.NoError(t, rows.Err())
+			require.Equal(t, tt.wantIDs, ids, "generated SQL: %s", converted.SQL)
+		})
+	}
+}

--- a/testcases/comprehension_tests.go
+++ b/testcases/comprehension_tests.go
@@ -11,6 +11,7 @@ func ComprehensionTests() []ConvertTestCase {
 			Category: CategoryComprehension,
 			WantSQL: map[dialect.Name]string{
 				dialect.PostgreSQL: "NOT EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE NOT (x != 'bad'))",
+				dialect.MySQL:      "(SELECT COUNT(*) FROM JSON_TABLE(string_list, '$[*]' COLUMNS(value TEXT PATH '$')) AS x WHERE NOT (x.value != 'bad')) = 0",
 				dialect.SQLite:     "NOT EXISTS (SELECT 1 FROM json_each(string_list) AS x WHERE NOT (x.value != 'bad'))",
 				dialect.DuckDB:     "NOT EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE NOT (x != 'bad'))",
 				dialect.BigQuery:   "NOT EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE NOT (x != 'bad'))",
@@ -23,6 +24,7 @@ func ComprehensionTests() []ConvertTestCase {
 			Category: CategoryComprehension,
 			WantSQL: map[dialect.Name]string{
 				dialect.PostgreSQL: "EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE x = 'good')",
+				dialect.MySQL:      "(SELECT COUNT(*) FROM JSON_TABLE(string_list, '$[*]' COLUMNS(value TEXT PATH '$')) AS x WHERE x.value = 'good') > 0",
 				dialect.SQLite:     "EXISTS (SELECT 1 FROM json_each(string_list) AS x WHERE x.value = 'good')",
 				dialect.DuckDB:     "EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE x = 'good')",
 				dialect.BigQuery:   "EXISTS (SELECT 1 FROM UNNEST(string_list) AS x WHERE x = 'good')",
@@ -35,6 +37,7 @@ func ComprehensionTests() []ConvertTestCase {
 			Category: CategoryComprehension,
 			WantSQL: map[dialect.Name]string{
 				dialect.PostgreSQL: "(SELECT COUNT(*) FROM UNNEST(string_list) AS x WHERE x = 'unique') = 1",
+				dialect.MySQL:      "(SELECT COUNT(*) FROM JSON_TABLE(string_list, '$[*]' COLUMNS(value TEXT PATH '$')) AS x WHERE x.value = 'unique') = 1",
 				dialect.SQLite:     "(SELECT COUNT(*) FROM json_each(string_list) AS x WHERE x.value = 'unique') = 1",
 				dialect.DuckDB:     "(SELECT COUNT(*) FROM UNNEST(string_list) AS x WHERE x = 'unique') = 1",
 				dialect.BigQuery:   "(SELECT COUNT(*) FROM UNNEST(string_list) AS x WHERE x = 'unique') = 1",


### PR DESCRIPTION
Closes #173 — and the test it adds found a real bug, which this PR also fixes.

## The test
`TestMySQLComprehensionRunsAgainstMySQL` mirrors `TestSQLiteComprehensionRunsAgainstSQLite`: it converts `exists`/`all`/`exists_one` comprehensions over a `JSON` array column and executes the generated SQL in a MySQL testcontainer, asserting the rows that come back. The MySQL half of #169 had shipped without ever being executed against a real server.

## The bug it caught
On MySQL 8.0 **and** 8.4, `EXISTS (SELECT 1 FROM JSON_TABLE(col, ...) AS a WHERE ...)` executes without error and matches **nothing**: the 8.x optimizer transforms a correlated `EXISTS` into a semijoin and loses the correlation to the `JSON_TABLE` source. Verified root cause locally (Homebrew MySQL 8.4.11 and 9.7.1):
- literal, server-side prepared, and Go-driver forms all return empty on 8.4, correct on 9.7
- `SET optimizer_switch='semijoin=off'` makes the same query correct on 8.4
- `LIMIT 1` inside the subquery does **not** help (MySQL ignores LIMIT in EXISTS)
- `(SELECT COUNT(*) FROM ...) > 0` / `= 0` / `= 1` are all correct on 8.4 — COUNT comparisons are never transformed

So cel2sql's `exists`/`all` output was silently wrong for every MySQL 8.x user, while `exists_one` (already COUNT-shaped) was fine.

## The fix
New `Dialect.WriteComprehensionExists` / `WriteComprehensionNotExists` let each dialect own the quantifier wrapper (same pattern as #169's `WriteIterVarRef`). All dialects keep the `EXISTS`/`NOT EXISTS` forms except MySQL, which writes the COUNT comparisons. Shared comprehension testcases gain MySQL expectations (there were none — which is how this shipped unnoticed).

Also bumps the MySQL integration containers from `mysql:8.0` (EOL April 2026) to `mysql:8.4` LTS — deliberately still an 8.x server, so the integration test exercises the buggy-optimizer generation.