### PR TITLE
chore: prepare CHANGELOG for v3.8.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [3.8.10] - 2026-08-22
 ### Fixed
 - **MySQL comprehensions**: `exists` and `all` now generate
   `(SELECT COUNT(*) FROM JSON_TABLE(...)) > 0` / `= 0` instead of


### PR DESCRIPTION
Moves the `[Unreleased]` CHANGELOG content into a `[3.8.10] - 2026-08-22` section ahead of tagging v3.8.10.

Included in this release:
- #177 — fix: MySQL comprehension `exists`/`all` silently matched nothing on MySQL 8.x (semijoin transform loses the `JSON_TABLE` correlation); now generates COUNT-comparison subqueries. Closes the loop on #173.