### PR TITLE
chore: move to the Go 1.26 toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25.x']  # Go 1.25.7+ required
+        go-version: ['1.26.x']
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
       run: go test -race -coverprofile=coverage.out -covermode=atomic -v ./...
 
     - name: Upload coverage to Codecov
-      if: matrix.go-version == '1.25.x'  # Only upload once
+      if: matrix.go-version == '1.26.x'  # Only upload once
       uses: codecov/codecov-action@v4
       with:
         file: ./coverage.out
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.x'
+        go-version: '1.26.x'
         cache: true
         check-latest: true
 

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'  # Use stable version for dependency updates
+          go-version: '1.26.x'  # Use stable version for dependency updates
           cache: true
           check-latest: true
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Download dependencies
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Download dependencies

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'  # Match project requirements
+          go-version: '1.26.x'
           cache: false
           check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6
+          version: v2.12
           args: --timeout=5m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'  # Use stable version for releases
+          go-version: '1.26.x'  # Use stable version for releases
           cache: true
           check-latest: true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'  # Use version that matches code requirements
+          go-version: '1.26.x'  # Use version that matches code requirements
           cache: true
           check-latest: true
 
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'  # Use version that matches code requirements
+          go-version: '1.26.x'  # Use version that matches code requirements
           cache: true
           check-latest: true
 
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           cache: true
           check-latest: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,23 @@ run:
   modules-download-mode: readonly
 
 linters:
+  settings:
+    goconst:
+      # Type-name switches, keyword maps, and String() methods repeat short
+      # domain literals by design; only flag heavy repetition.
+      ignore-tests: true
+      min-occurrences: 8
+  exclusions:
+    rules:
+      - path: ^examples/
+        linters:
+          - goconst
+      - path: ^testcases/
+        linters:
+          - goconst
+      - path: ^test/
+        linters:
+          - goconst
   enable:
     # Core linters (enabled by default)
     - errcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- **Go 1.26 toolchain** (#174): the `go` directive moves to 1.26.7 (latest
+  1.26 patch, keeping the OSV/govulncheck stdlib scans clean) and all CI
+  workflows build with Go 1.26.x. golangci-lint in CI moves v2.6 → v2.12,
+  with `goconst` tuned to stop flagging type-name switches, keyword maps,
+  and fixture data. Consumers now need a Go 1.26+ toolchain (older `go`
+  binaries with toolchain auto-download still work).
 
 ## [3.8.10] - 2026-08-22
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 cel2sql converts CEL (Common Expression Language) expressions to SQL conditions. It supports six SQL dialects: PostgreSQL (default), MySQL, SQLite, DuckDB, BigQuery, and Apache Spark SQL.
 
 **Module**: `github.com/spandigital/cel2sql/v3`
-**Go Version**: 1.25+
-**Current Version**: v3.7.1
+**Go Version**: 1.26+
+**Current Version**: v3.8.10
 
 ## Common Development Commands
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Convert [CEL (Common Expression Language)](https://cel.dev/) expressions to SQL for PostgreSQL, MySQL, SQLite, DuckDB, BigQuery, and Apache Spark SQL
 
-[![Go Version](https://img.shields.io/badge/Go-1.25%2B-blue)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/Go-1.26%2B-blue)](https://golang.org)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17-336791)](https://www.postgresql.org)
 [![MySQL](https://img.shields.io/badge/MySQL-8.0-4479A1)](https://www.mysql.com)
 [![SQLite](https://img.shields.io/badge/SQLite-3-003B57)](https://www.sqlite.org)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spandigital/cel2sql/v3
 
-go 1.25.13
+go 1.26.7
 
 require (
 	cloud.google.com/go/bigquery v1.81.0


### PR DESCRIPTION
Closes #174.

## Changes
- **`go` directive 1.25.13 → 1.26.7** — the latest 1.26 patch, so the OSV and govulncheck stdlib scans stay clean. Deliberately not 1.27.0: a fresh .0 release is the same accumulating-stdlib-vulns trap that kept us pinning patch releases on 1.25.
- **All workflows build with Go 1.26.x** (CI, security, fuzzing, release, dependency-update).
- **golangci-lint action `v2.6` → `v2.12`** — the v2.6 binary is built with go1.25 and refuses configs targeting Go 1.26 ("the Go language version used to build golangci-lint is lower than the targeted Go version"). Bonus: v2.6's remote config-schema download has caused repeated flaky lint failures recently (two in the last day); newer releases don't have that timeout.
- **`goconst` tuned for the v2.12 analyzer**, which flags ~50 findings the old binary didn't — all in type-name switches, SQL keyword maps, `String()` methods, and test fixture data, where extracting constants would hurt readability. Config now ignores tests, `examples/`, `testcases/`, `test/`, and requires 8 occurrences. `golangci-lint run ./...` under v2.12.2 is clean.
- README/CLAUDE.md version references updated.

## Consumer impact
The module now requires a Go 1.26+ toolchain. Go's toolchain auto-download means older `go` binaries (1.21+) still build it transparently.

## Follow-up
This unblocks #172 (cel.dev/cel-go migration), which may need the newer toolchain.

## Testing
`go build ./...` and `go test ./...` pass locally under go1.26.7 (Docker-dependent testcontainers suites excluded as usual; CI covers them).