### PR TITLE
chore: migrate cel-go to the cel.dev/cel-go module path

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -87,7 +87,7 @@ info.metadata.corpus.section == "Guide" && info.metadata.version.major == 2
 
 ### Dependencies
 
-- **CEL**: `github.com/google/cel-go` - Core CEL functionality
+- **CEL**: `cel.dev/cel-go` - Core CEL functionality
 - **PostgreSQL**: `github.com/jackc/pgx/v5` - Database driver
 - **Protobuf**: Required for CEL (don't remove these dependencies)
 - **Testing**: `github.com/stretchr/testify`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 ### Changed
+- **cel-go moves to the `cel.dev/cel-go` module path** (#172): cel-go
+  v0.32.0 renamed its module, and v0.31.0 was the last release under
+  `github.com/google/cel-go`. All imports and docs now use the new path,
+  picking up v0.32.0 (JWT/HMAC libraries, timestamp parsing helpers,
+  concurrency fixes). No cel2sql API changes — but applications that pass
+  `*cel.Ast` values into cel2sql must build them with `cel.dev/cel-go`
+  types from the same cel-go version, so this is effectively a
+  compile-time migration for consumers too.
 - **Go 1.26 toolchain** (#174): the `go` directive moves to 1.26.7 (latest
   1.26 patch, keeping the OSV/govulncheck stdlib scans clean) and all CI
   workflows build with Go 1.26.x. golangci-lint in CI moves v2.6 → v2.12,

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ package main
 
 import (
     "fmt"
-    "github.com/google/cel-go/cel"
+    "cel.dev/cel-go/cel"
     "github.com/spandigital/cel2sql/v3"
     "github.com/spandigital/cel2sql/v3/pg"
 )
@@ -645,7 +645,7 @@ Apache 2.0 - See [LICENSE](LICENSE) for details.
 
 ## Related Projects
 
-- [CEL-Go](https://github.com/google/cel-go) - Common Expression Language implementation in Go
+- [CEL-Go](https://github.com/cel-expr/cel-go) - Common Expression Language implementation in Go
 - [CEL Spec](https://github.com/google/cel-spec) - Common Expression Language specification
 
 ## Need Help?

--- a/analysis.go
+++ b/analysis.go
@@ -6,9 +6,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/operators"
-	"github.com/google/cel-go/common/overloads"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/common/operators"
+	"cel.dev/cel-go/common/overloads"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/spandigital/cel2sql/v3/dialect"

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3/dialect"
 	dialectbq "github.com/spandigital/cel2sql/v3/dialect/bigquery"
 	dialectduckdb "github.com/spandigital/cel2sql/v3/dialect/duckdb"

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/ext"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/ext"
 
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"

--- a/bigquery/provider.go
+++ b/bigquery/provider.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
+	"cel.dev/cel-go/checker/decls"
+	"cel.dev/cel-go/common/types"
 	bq "cloud.google.com/go/bigquery"
-	"github.com/google/cel-go/checker/decls"
-	"github.com/google/cel-go/common/types"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/spandigital/cel2sql/v3/internal/celprovider"

--- a/bigquery/provider_test.go
+++ b/bigquery/provider_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"cel.dev/cel-go/common/types"
 	bq "cloud.google.com/go/bigquery"
-	"github.com/google/cel-go/common/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"

--- a/bigquery_integration_test.go
+++ b/bigquery_integration_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"cel.dev/cel-go/cel"
 	"cloud.google.com/go/bigquery"
-	"github.com/google/cel-go/cel"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	tcbigquery "github.com/testcontainers/testcontainers-go/modules/gcloud/bigquery"

--- a/byte_array_test.go
+++ b/byte_array_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3/pg"
 	"github.com/stretchr/testify/require"
 )

--- a/cel2sql.go
+++ b/cel2sql.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/operators"
-	"github.com/google/cel-go/common/overloads"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/common/operators"
+	"cel.dev/cel-go/common/overloads"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/spandigital/cel2sql/v3/dialect"
@@ -23,7 +23,7 @@ import (
 )
 
 // Implementations based on `google/cel-go`'s unparser
-// https://github.com/google/cel-go/blob/master/parser/unparser.go
+// https://cel.dev/cel-go/blob/master/parser/unparser.go
 
 // Resource limit constants.
 const (

--- a/cel2sql_test.go
+++ b/cel2sql_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/comprehension_depth_test.go
+++ b/comprehension_depth_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 	"github.com/stretchr/testify/require"

--- a/comprehensions.go
+++ b/comprehensions.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/google/cel-go/common/operators"
+	"cel.dev/cel-go/common/operators"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 

--- a/comprehensions_coverage_test.go
+++ b/comprehensions_coverage_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/comprehensions_edge_cases_test.go
+++ b/comprehensions_edge_cases_test.go
@@ -4,7 +4,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3/pg"
 )
 

--- a/comprehensions_test.go
+++ b/comprehensions_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/context_test.go
+++ b/context_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -74,7 +74,7 @@ This project converts [CEL (Common Expression Language)](https://opensource.goog
 
 ### Dependencies
 
-- **CEL**: `github.com/google/cel-go` - Core CEL functionality
+- **CEL**: `cel.dev/cel-go` - Core CEL functionality
 - **PostgreSQL**: `github.com/jackc/pgx/v5` - Database driver
 - **Protobuf**: Required for CEL (don't remove these dependencies)
 - **Testing**: `github.com/stretchr/testify`

--- a/coverage_80_test.go
+++ b/coverage_80_test.go
@@ -3,8 +3,8 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/ext"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/ext"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 	"github.com/stretchr/testify/assert"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/google/cel-go/cel"
+    "cel.dev/cel-go/cel"
     "github.com/spandigital/cel2sql/v3"
     "github.com/spandigital/cel2sql/v3/pg"
 )
@@ -178,7 +178,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/google/cel-go/cel"
+    "cel.dev/cel-go/cel"
     "github.com/spandigital/cel2sql/v3"
     "github.com/spandigital/cel2sql/v3/pg"
 )

--- a/docs/json-support.md
+++ b/docs/json-support.md
@@ -158,7 +158,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/google/cel-go/cel"
+    "cel.dev/cel-go/cel"
     "github.com/spandigital/cel2sql/v3"
     "github.com/spandigital/cel2sql/v3/pg"
 )

--- a/docs/regex-matching.md
+++ b/docs/regex-matching.md
@@ -228,7 +228,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/google/cel-go/cel"
+    "cel.dev/cel-go/cel"
     "github.com/spandigital/cel2sql/v3"
     "github.com/spandigital/cel2sql/v3/pg"
 )

--- a/duckdb/provider.go
+++ b/duckdb/provider.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/cel-go/checker/decls"
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/checker/decls"
+	"cel.dev/cel-go/common/types"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/spandigital/cel2sql/v3/internal/celprovider"

--- a/duckdb/provider_test.go
+++ b/duckdb/provider_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/common/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/edgecase_coverage_test.go
+++ b/edgecase_coverage_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/error_messages_test.go
+++ b/error_messages_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spandigital/cel2sql/v3"

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 )

--- a/examples/comprehensions/main.go
+++ b/examples/comprehensions/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 )

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 )

--- a/examples/index_analysis/main.go
+++ b/examples/index_analysis/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/dialect"
 	dialectbq "github.com/spandigital/cel2sql/v3/dialect/bigquery"

--- a/examples/load_table_schema/main.go
+++ b/examples/load_table_schema/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 )

--- a/examples/logging/main.go
+++ b/examples/logging/main.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 )

--- a/examples/parameterized/main.go
+++ b/examples/parameterized/main.go
@@ -15,7 +15,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	_ "github.com/lib/pq"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"

--- a/examples/string_extensions/README.md
+++ b/examples/string_extensions/README.md
@@ -160,7 +160,7 @@ person.tags.filter(t, t.startsWith('a')).join(',')
 
 ## Related Documentation
 
-- [CEL String Extensions](https://github.com/google/cel-go/tree/master/ext#strings)
+- [CEL String Extensions](https://github.com/cel-expr/cel-go/tree/master/ext#strings)
 - [PostgreSQL String Functions](https://www.postgresql.org/docs/current/functions-string.html)
 - [PostgreSQL Array Functions](https://www.postgresql.org/docs/current/functions-array.html)
 - [cel2sql Operators Reference](../../docs/operators-reference.md)

--- a/examples/string_extensions/main.go
+++ b/examples/string_extensions/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/ext"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/ext"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 )

--- a/explain_validation_test.go
+++ b/explain_validation_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"

--- a/field_validation_test.go
+++ b/field_validation_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spandigital/cel2sql/v3"

--- a/final_coverage_test.go
+++ b/final_coverage_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 	"github.com/spandigital/cel2sql/v3/sqltypes"

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/spandigital/cel2sql/v3
 go 1.26.7
 
 require (
+	cel.dev/cel-go v0.32.0
 	cloud.google.com/go/bigquery v1.81.0
 	github.com/go-sql-driver/mysql v1.10.0
-	github.com/google/cel-go v0.31.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lib/pq v1.12.3
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cel.dev/cel-go v0.32.0 h1:irvpFKr5EuGPyxeME03ERh0rii1TX+BDAnB9eL3IvNk=
+cel.dev/cel-go v0.32.0/go.mod h1:DnVip7tpJSsgZymwfT+m1tnEVy3ivAjSMXPx12YrMkU=
 cel.dev/expr v0.25.2 h1:K6j46C81hXtZQfuX60cVWQFBJahKSE2gfRbNuvr5bFs=
 cel.dev/expr v0.25.2/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
@@ -93,8 +95,6 @@ github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/cel-go v0.31.0 h1:H0bhpFTqOvmHrBGrWKp7ZlhBm5Hh8PYUEXnwxT1LL7A=
-github.com/google/cel-go v0.31.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
 github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/celprovider/base.go
+++ b/internal/celprovider/base.go
@@ -13,8 +13,8 @@
 package celprovider
 
 import (
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
+	"cel.dev/cel-go/common/types"
+	"cel.dev/cel-go/common/types/ref"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/spandigital/cel2sql/v3/schema"

--- a/json_escaping_test.go
+++ b/json_escaping_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spandigital/cel2sql/v3"

--- a/json_integration_validation_test.go
+++ b/json_integration_validation_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"

--- a/json_jsonb_coverage_test.go
+++ b/json_jsonb_coverage_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/json_variables_test.go
+++ b/json_variables_test.go
@@ -3,8 +3,8 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/common/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/logging_test.go
+++ b/logging_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/multidim_array_test.go
+++ b/multidim_array_test.go
@@ -3,7 +3,7 @@ package cel2sql
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3/pg"
 )
 

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/cel-go/checker/decls"
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/checker/decls"
+	"cel.dev/cel-go/common/types"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/spandigital/cel2sql/v3/internal/celprovider"

--- a/mysql/provider_test.go
+++ b/mysql/provider_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"cel.dev/cel-go/common/types"
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/google/cel-go/common/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"

--- a/mysql_integration_test.go
+++ b/mysql_integration_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"cel.dev/cel-go/cel"
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/google/cel-go/cel"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	tcmysql "github.com/testcontainers/testcontainers-go/modules/mysql"

--- a/mysql_iteration_variable_test.go
+++ b/mysql_iteration_variable_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/require"
 
 	"github.com/spandigital/cel2sql/v3"

--- a/operators.go
+++ b/operators.go
@@ -1,7 +1,7 @@
 package cel2sql
 
 import (
-	"github.com/google/cel-go/common/operators"
+	"cel.dev/cel-go/common/operators"
 )
 
 // standardSQLBinaryOperators maps CEL binary operators to PostgreSQL SQL operators

--- a/operators_integration_test.go
+++ b/operators_integration_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"

--- a/output_length_test.go
+++ b/output_length_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3/pg"
 	"github.com/stretchr/testify/require"
 )

--- a/param_start_index_test.go
+++ b/param_start_index_test.go
@@ -3,8 +3,8 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/common/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/parameterized_integration_test.go
+++ b/parameterized_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/parameterized_test.go
+++ b/parameterized_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pg/postgres17_compat_test.go
+++ b/pg/postgres17_compat_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pg/provider.go
+++ b/pg/provider.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/cel-go/checker/decls"
-	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/common/types/ref"
+	"cel.dev/cel-go/checker/decls"
+	"cel.dev/cel-go/common/types"
+	"cel.dev/cel-go/common/types/ref"
 	"github.com/jackc/pgx/v5/pgxpool"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 

--- a/pg/provider_test.go
+++ b/pg/provider_test.go
@@ -4,7 +4,7 @@ package pg_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/common/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/spandigital/cel2sql/v3/pg"

--- a/pg/provider_testcontainer_test.go
+++ b/pg/provider_testcontainer_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/phase1_correctness_test.go
+++ b/phase1_correctness_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3/pg"
 )
 

--- a/recursion_depth_test.go
+++ b/recursion_depth_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/spandigital/cel2sql/v3/pg"
 	"github.com/stretchr/testify/require"
 )

--- a/redos_test.go
+++ b/redos_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/regex_conversion_test.go
+++ b/regex_conversion_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/spark/provider.go
+++ b/spark/provider.go
@@ -9,8 +9,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/cel-go/checker/decls"
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/checker/decls"
+	"cel.dev/cel-go/common/types"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/spandigital/cel2sql/v3/internal/celprovider"

--- a/spark/provider_test.go
+++ b/spark/provider_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/common/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/sqlite/provider.go
+++ b/sqlite/provider.go
@@ -9,8 +9,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/cel-go/checker/decls"
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/checker/decls"
+	"cel.dev/cel-go/common/types"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/spandigital/cel2sql/v3/internal/celprovider"

--- a/sqlite/provider_test.go
+++ b/sqlite/provider_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/google/cel-go/common/types"
+	"cel.dev/cel-go/common/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"

--- a/sqlite_integration_test.go
+++ b/sqlite_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
 

--- a/sqlite_iteration_variable_test.go
+++ b/sqlite_iteration_variable_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
 

--- a/sqltypes/types.go
+++ b/sqltypes/types.go
@@ -2,8 +2,8 @@
 package sqltypes
 
 import (
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/checker/decls"
 )
 
 var (

--- a/string_functions_test.go
+++ b/string_functions_test.go
@@ -3,8 +3,8 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/ext"
+	"cel.dev/cel-go/cel"
+	"cel.dev/cel-go/ext"
 	"github.com/spandigital/cel2sql/v3"
 	"github.com/spandigital/cel2sql/v3/pg"
 	"github.com/stretchr/testify/assert"

--- a/testutil/env.go
+++ b/testutil/env.go
@@ -3,7 +3,7 @@ package testutil
 import (
 	"fmt"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 
 	"github.com/spandigital/cel2sql/v3"
 	dialectpkg "github.com/spandigital/cel2sql/v3/dialect"

--- a/timestamps.go
+++ b/timestamps.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/cel-go/common/operators"
-	"github.com/google/cel-go/common/overloads"
+	"cel.dev/cel-go/common/operators"
+	"cel.dev/cel-go/common/overloads"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 

--- a/transform_struct_coverage_test.go
+++ b/transform_struct_coverage_test.go
@@ -3,7 +3,7 @@ package cel2sql_test
 import (
 	"testing"
 
-	"github.com/google/cel-go/cel"
+	"cel.dev/cel-go/cel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/utils.go
+++ b/utils.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/cel-go/common/operators"
+	"cel.dev/cel-go/common/operators"
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 


### PR DESCRIPTION
Closes #172.

cel-go v0.32.0 renamed its module from `github.com/google/cel-go` to `cel.dev/cel-go` — v0.31.0 was the last release under the old path, so staying meant no further cel-go updates ever.

## Changes
- `go.mod`: `github.com/google/cel-go v0.31.0` → `cel.dev/cel-go v0.32.0`
- Import path rewritten across all Go files (69 files) and code samples in README/docs/examples
- Picks up v0.32.0's additions along the way: JWT/HMAC libraries, timestamp parsing helpers, native JSON support, concurrency fixes

The path rename turned out to be v0.32.0's **only** breaking change — no API adjustments were needed anywhere in the converter, providers, or tests.

## Consumer impact
No cel2sql API changes. However, applications pass `*cel.Ast` values into `cel2sql.Convert`, and those must now be built with `cel.dev/cel-go` types — the old and new module paths are distinct types to the compiler. Consumers upgrade their own cel-go import when they take this version, making this a coordinated compile-time migration (a good candidate for a minor version bump).

## Testing
- `go build ./...`, `go test ./...` pass locally under go1.26.7 (Docker-dependent testcontainers suites excluded as usual; CI covers them)
- `golangci-lint run ./...` under v2.12: 0 issues
- Rebased on #179's Go 1.26 toolchain move