### PR TITLE
chore: prepare CHANGELOG for v3.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [3.9.0] - 2026-08-22
 ### Changed
 - **cel-go moves to the `cel.dev/cel-go` module path** (#172): cel-go
   v0.32.0 renamed its module, and v0.31.0 was the last release under


### PR DESCRIPTION
Moves the `[Unreleased]` CHANGELOG content into a `[3.9.0] - 2026-08-22` section ahead of tagging v3.9.0.

Minor (not patch) because both changes are coordinated compile-time migrations for consumers:
- #180 — cel-go moves to the `cel.dev/cel-go` module path (v0.32.0); apps must build their `*cel.Ast` values with the new path (#172)
- #179 — Go 1.26 toolchain; the module now requires Go 1.26+ (#174)