### PR TITLE
chore: prepare CHANGELOG for v3.9.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## [Unreleased]
 
+## [3.9.3] - 2026-09-09
+### Changed
+- **Dependencies**: 22 grouped minor/patch Go module bumps (#190) —
+  `cloud.google.com/go/bigquery` 1.81.0 → 1.83.0,
+  `github.com/go-sql-driver/mysql` 1.10.0 → 1.10.1,
+  `google.golang.org/api` 0.293.0 → 0.297.0,
+  `google.golang.org/grpc` 1.83.1 → 1.83.2 and
+  `modernc.org/sqlite` 1.57.0 → 1.58.0 among the direct updates, plus
+  `golang.org/x/crypto` 0.55.0 → 0.56.0,
+  `github.com/klauspost/compress` 1.19.2 → 1.20.0 and the
+  OpenTelemetry 1.45.0 → 1.46.0 set among the indirect ones. The `go`
+  directive stays on 1.26.7. No cel2sql API or behavior changes.
+
+## [3.9.2] - 2026-08-28
+### Changed
+- **Dependencies**: 8 grouped minor/patch Go module bumps (#187), all
+  indirect — `cloud.google.com/go/auth` 0.23.1 → 0.23.2,
+  `github.com/docker/go-connections` 0.7.0 → 0.8.1,
+  `github.com/ebitengine/purego` 0.10.1 → 0.10.2,
+  `github.com/moby/moby/client` 0.5.0 → 0.5.1,
+  `github.com/shirou/gopsutil/v4` 4.26.6 → 4.26.7,
+  `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp`
+  0.69.0 → 0.70.0, `modernc.org/libc` 1.75.3 → 1.75.4 and
+  `modernc.org/memory` 1.12.0 → 1.12.1.
+- **CI**: `github/codeql-action` 3 → 4 in the security workflow (#188).
+
+  This section was backfilled during the v3.9.3 release: v3.9.2 was tagged
+  and published on 2026-08-28 without a CHANGELOG entry.
+
 ## [3.9.1] - 2026-08-23
 ### Changed
 - **CI**: retired the scheduled Dependency Update workflow (#176). Its PRs


### PR DESCRIPTION
## Summary

Prepares the CHANGELOG for a **v3.9.3** patch release. Patch is the right bump: the only commit since `v3.9.2` is a Dependabot group update touching `go.mod`/`go.sum` only, with no API or behavior change.

### Release content

- **#190** — 22 grouped minor/patch Go module bumps. Direct: BigQuery 1.81.0 → 1.83.0, mysql driver 1.10.0 → 1.10.1, google.golang.org/api 0.293.0 → 0.297.0, gRPC 1.83.1 → 1.83.2, modernc.org/sqlite 1.57.0 → 1.58.0. The `go` directive stays on 1.26.7.

### Also: backfills the missing v3.9.2 section

`v3.9.2` was tagged and published on 2026-08-28 but never got a CHANGELOG entry, so its contents (#187 dependency bumps, #188 codeql-action 3 → 4) were invisible in the changelog. That section is now filled in from the tag range, with a short note recording the backfill.

Two process notes for that release, neither fixed here since the tag is already published:

- `v3.9.2` is a **lightweight** tag, while `v3.9.0` and `v3.9.1` are annotated. The release workflow reads the tag message, so annotated is the intended form.
- It was cut without the CHANGELOG step.

`v3.9.3` will be tagged annotated, per the documented flow.

## Verification

- All four workflows passed on `dc50d53`, the #190 merge commit: CI, golangci-lint, Security, Fuzzing.
- Locally on the #190 branch: `go mod verify`, `go build ./...` and `go vet ./...` all clean. The only test failures were testcontainer tests that require Docker, which was not running on that machine; CI ran those same tests with Docker and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)