### PR TITLE
chore: prepare CHANGELOG for v3.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+## [3.10.0] - 2026-09-09
 ### Fixed
 - **Comprehension variables are JSON because of what they range over, not what
   they are called.** `isJSONObjectFieldAccess` decided that field access on a


### PR DESCRIPTION
Splits `## [Unreleased]` into `## [3.10.0] - 2026-09-09`. No code changes.

## What's in v3.10.0

| PR | |
|---|---|
| #192 | `feat`: `WithPlaceholderStyle` — render `?` for callers whose driver rebinds placeholders (GORM, `sqlx.Rebind`, squirrel) |
| #193 | `fix`: `has()` detects JSON columns from the schema, not a hardcoded name list |
| #194 | `fix`: comprehension JSON access derives from the range, not variable names |

Together, #193 and #194 remove the last hardcoded column- and variable-name lists from the converter, completing the sweep started in #62 (#61, #59):

```console
$ grep -rn '\[\]string{"' --include='*.go' . | grep -v _test | grep -v /examples/
$
```

## Minor, not major

Two BREAKING behaviour notes are recorded under `### Changed`, but both stay within `/v3` per the skill's rule — the same call made for #113, whose heuristic removal was BREAKING with a niche blast radius. Neither changes an exported signature:

- `has()` on a JSON column now requires the column to be declared via `WithSchemas` or `WithJSONVariables`.
- Field access on a comprehension variable follows the schema rather than the variable's name.

Callers already passing schemas are unaffected; those with JSON columns outside the old seven names get correct SQL for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)